### PR TITLE
Feature/inline functions

### DIFF
--- a/compiler/asm.torth
+++ b/compiler/asm.torth
@@ -1143,11 +1143,39 @@ function append_programs_assembly_code file_name:str program:Program sub_program
   func get_function_start_asm file_name append_file
 
   // Write assembly code of each Op in program
-  sub_programs program generate_program_ops_assembly_code
-  file_name append_file
+  sub_programs program file_name append_program_ops_assembly_code
 
   // Prepend the Func's beginning code and prepend the ending code
   func get_function_end_asm file_name append_file
+end
+
+// Generate assembly for program
+function append_program_ops_assembly_code
+  file_name:str
+  program:Program
+  sub_programs:List[Program]
+-> :
+  program cast(List) List.len
+  0
+  take
+    index
+    program.len
+  in
+
+  // Generate assembly for each Op in Program
+  while index program.len < do
+
+    // Get the current Op
+    index program cast(List) List.nth Op.load
+    take op in
+
+    // Generate assembly for Op
+    op get_op_comment_asm file_name append_file
+    sub_programs program op get_op_asm file_name append_file
+
+    // Append the current Op's assembly to file
+    index 1 + index =
+  done
 end
 
 function generate_program_ops_assembly_code
@@ -1170,7 +1198,7 @@ function generate_program_ops_assembly_code
     index program cast(List) List.nth Op.load
     take op in
 
-    // Generate comment for Op
+    // Generate assembly for Op
     assembly_code
     op get_op_comment_asm str.cat
     sub_programs program op get_op_asm str.cat

--- a/compiler/asm.torth
+++ b/compiler/asm.torth
@@ -29,19 +29,21 @@ section .bss
 end
 
 // Get Assembly for certain Op
-// Params: Pointer to Op (PTR), Program
-// Return: Assembly
-function get_op_asm op:Op program:Program -> str :
+function get_op_asm op:Op program:Program sub_programs:List[Program] -> str :
   // Assert that every OpType has been taken into account
-  if OpType.len 28 != do
+  if OpType.len 29 != do
     "All OpTypes are not taken into account in `get_op_asm` function.\n"
     "ASSERTION_ERROR" CompilerError
   endif
 
-  // Save Op and Token.value in Binding
-  op Op.token Token.value
+  op Op.token
+  dup Token.value
   op Op.type
-  take op_type token_value in
+  take
+    op_type
+    token_value
+    token
+  in
 
   // Get assembly for the correct OpType
   if
@@ -78,6 +80,28 @@ function get_op_asm op:Op program:Program -> str :
   elif op_type OpType.FUNCTION_CALL == do
     token_value get_function_call_asm
     return
+  elif op_type OpType.INLINE_FUNCTION_CALL == do
+    0
+    sub_programs cast(List) List.len
+    take sub_programs.len program_index in
+
+    // Get the implementation of the inline function
+    while program_index sub_programs.len < do
+      program_index sub_programs cast(List) List.nth ptr.load cast(Program)
+      dup cast(List) List.first Op.load Op.func
+      take func program in
+
+      // Expand assembly from the called inline function
+      if func Func.name token_value streq do
+        sub_programs program generate_program_ops_assembly_code
+        return
+      endif
+      program_index 1 + program_index =
+    done
+
+    token
+    f"Inline function definition of '{token_value}' was not found"
+    "ASSERTION_ERROR" CompilerErrorWithToken
   elif op_type OpType.PEEK == do
     get_peek_asm
     return
@@ -935,8 +959,15 @@ function generate_assembly_file
     index sub_programs cast(List) List.nth ptr.load cast(Program)
     take program in
 
+    // Do not generate assembly for inline functions
+    // The inline functions are expanded when they are called
+    if program cast(List) List.first Op.load Op.func Func.is_inline do
+      index 1 + index =
+      continue
+    endif
+
     // Get assembly code for the current Program
-    program file_name append_programs_assembly_code
+    sub_programs program file_name append_programs_assembly_code
 
     // Add strings from the program to the .data section
     program get_string_variables_for_data_section
@@ -1102,11 +1133,7 @@ function get_function_end_asm func:Func -> str :
   ret\n\n"
 end
 
-function append_programs_assembly_code file_name:str program:Program :
-  program cast(List) List.len
-  0
-  take index program.len in
-
+function append_programs_assembly_code file_name:str program:Program sub_programs:List[Program] :
   // Get the Func's name to be added to the assembly code
   // Exception: MAIN Func should be named '_start'
   program cast(List) List.first Op.load Op.func
@@ -1114,6 +1141,27 @@ function append_programs_assembly_code file_name:str program:Program :
 
   // Write Func's start assembly to file
   func get_function_start_asm file_name append_file
+
+  // Write assembly code of each Op in program
+  sub_programs program generate_program_ops_assembly_code
+  file_name append_file
+
+  // Prepend the Func's beginning code and prepend the ending code
+  func get_function_end_asm file_name append_file
+end
+
+function generate_program_ops_assembly_code
+  program:Program
+  sub_programs:List[Program]
+-> str :
+  "" str.copy
+  program cast(List) List.len
+  0
+  take
+    index
+    program.len
+    assembly_code
+  in
 
   // Generate assembly for each Op in Program
   while index program.len < do
@@ -1123,19 +1171,16 @@ function append_programs_assembly_code file_name:str program:Program :
     take op in
 
     // Generate comment for Op
-    op get_op_comment_asm file_name append_file
-
-    // Concatenate Op's Assembly to op_asm
-    program op get_op_asm
-    peek op_asm in file_name append_file
-    op_asm str.delete
+    assembly_code
+    op get_op_comment_asm str.cat
+    sub_programs program op get_op_asm str.cat
+    assembly_code =
 
     // Append the current Op's assembly to file
     index 1 + index =
   done
 
-  // Prepend the Func's beginning code and prepend the ending code
-  func get_function_end_asm file_name append_file
+  assembly_code
 end
 
 // Returns the current IF block's ENDIF Op

--- a/compiler/class/Func.torth
+++ b/compiler/class/Func.torth
@@ -8,6 +8,7 @@ class Func
   tokens:List[Token]
   variables:List[Variable]
   is_used:bool
+  is_inline:bool
 
   method init
     name:str
@@ -15,6 +16,7 @@ class Func
     tokens:List[Token]
     variables:List[Variable]
     is_used:bool
+    is_inline:bool
   -> Func :
     Func.size malloc cast(Func)
     take func in
@@ -24,6 +26,7 @@ class Func
     tokens    func Func->tokens
     variables func Func->variables
     is_used   func Func->is_used
+    is_inline func Func->is_inline
     func
   end
 

--- a/compiler/defs.torth
+++ b/compiler/defs.torth
@@ -22,6 +22,7 @@ ENUM OpType.len 1 :
   OpType.FUNCTION_RETURN
   OpType.IF
   OpType.IN
+  OpType.INLINE_FUNCTION_CALL
   OpType.INTRINSIC
   OpType.PEEK
   OpType.PEEK_BIND

--- a/compiler/lex.torth
+++ b/compiler/lex.torth
@@ -776,12 +776,27 @@ function get_functions
   while index tokens cast(List) List.len < do
     // Get current word
     index tokens cast(List) List.nth Token.load
-    Token.value str.copy str.upper
-    take token_upper in
+    dup Token.value str.copy
+    take token_value token in
 
-    if token_upper "FUNCTION" streq do
+    if token_value str.upper "FUNCTION" streq do
       index 1 + index =
-      "" constants index tokens parse_function
+      "" False constants index tokens parse_function
+      functions cast(List) List.append
+    elif token_value str.upper "INLINE" streq do
+      // Verify that the next token is "FUNCTION"
+      if
+        index 1 + tokens cast(List) List.nth Token.load Token.value
+        peek next_token in
+        str.copy str.upper "FUNCTION" streq not
+      do
+        token
+        f"Token '{token_value}' should be followed by 'FUNCTION' keyword but got {next_token}"
+        "SYNTAX_ERROR" CompilerErrorWithToken
+      endif
+
+      index 2 + index =
+      "" True constants index tokens parse_function
       functions cast(List) List.append
     endif
     index 1 + index =
@@ -801,11 +816,14 @@ end
 //    tokens:       List[Token]
 //    token_index:  int
 //    constants:    List[Constant]
+//    class_name:   str
+//    is_inline     bool
 // Return Func
 function parse_function
   tokens:List[Token]
   token_index:int
   constants:List[Constant]
+  is_inline:bool
   class_name:str
 -> Func :
   // Initialize variables
@@ -826,6 +844,7 @@ function parse_function
     FUNCTION_PART_DELIMITERS
   in
 
+  // Verify that there are more tokens to parse
   if token_index tokens cast(List) List.len >= do
     tokens cast(List) List.last Token.load Token.value
     take token_value in
@@ -880,12 +899,14 @@ function parse_function
           function_tokens cast(List) List.append
         endif
 
-        // return Func(function_name, signature, function_tokens, variables, is_used)
+        // return Func(function_name, signature, function_tokens, variables, is_used, is_inline)
+        is_inline
         is_used
         variables
         function_tokens
         return_types param_types Signature.init
-        function_name Func.init
+        function_name
+        Func.init
         take func in
 
         // Set MAIN function as used
@@ -1118,7 +1139,7 @@ function parse_class
     if token_value str.copy str.upper "METHOD" streq do
       // Parse all methods
       token_index 1 + token_index =
-      class_name constants token_index tokens parse_function
+      class_name False constants token_index tokens parse_function
       take class_method in
 
       // Add method to list of functions
@@ -1226,7 +1247,7 @@ function get_object_size_function
   return_types List.init Signature.init
   take signature in
 
-  False List.init cast(List[Variable]) tokens signature function_name Func.init
+  False False List.init cast(List[Variable]) tokens signature function_name Func.init
 end
 
 function generate_attribution_function
@@ -1270,7 +1291,7 @@ function generate_attribution_function
   take tokens in
 
   // Create Func and append it to list of Funcs
-  False List.init cast(List[Variable]) tokens signature function_name Func.init
+  False False List.init cast(List[Variable]) tokens signature function_name Func.init
 end
 
 function get_attribute_function_tokens

--- a/compiler/program.torth
+++ b/compiler/program.torth
@@ -117,7 +117,7 @@ function get_tokens_op_type
   constants:List[Constant]
 -> int :
   // Assert that every OpType has been taken into account
-  if OpType.len 28 != do
+  if OpType.len 29 != do
     "All OpTypes are not taken into account in `get_tokens_op_type` function.\n"
     "ASSERTION_ERROR" CompilerError
   endif
@@ -196,10 +196,18 @@ function get_tokens_op_type
     "Unknown VarType '" token_vartype itoa str.cat
     "VALUE_ERROR" CompilerErrorWithToken
   elif functions token_value function_exists do
-    // Mark function as used
     functions token_value get_function_by_name
-    TRUE swap Func->is_used
+    take func in
 
+    // Mark function as used
+    TRUE func Func->is_used
+
+    // Inline function call
+    if func Func.is_inline do
+      OpType.INLINE_FUNCTION_CALL return
+    endif
+
+    // Regular function call
     OpType.FUNCTION_CALL return
   elif functions "&" token_value str.removesuffix function_exists do
     // Mark function as used

--- a/compiler/typecheck.torth
+++ b/compiler/typecheck.torth
@@ -144,7 +144,7 @@ function type_check_op
   if_block_return_stacks:List[TypeStack]
 -> TypeCheckInfo :
   // Assert that every OpType has been taken into account
-  if OpType.len 28 != do
+  if OpType.len 29 != do
     "All OpTypes are not taken into account in `type_check_op` function.\n"
     "ASSERTION_ERROR" CompilerError
   endif
@@ -202,7 +202,12 @@ function type_check_op
     // Set type_check_info.else_present to False
     False type_check_info TypeCheckInfo->else_present
     type_check_info return
-  elif op_type OpType.FUNCTION_CALL == do
+  elif
+    // Type check inline functions and regular functions similarly
+    op_type OpType.FUNCTION_CALL ==
+    op_type OpType.INLINE_FUNCTION_CALL ==
+    ||
+  do
     functions type_stack token type_check_function_call
     type_check_info return
   elif op_type OpType.IF == do

--- a/compiler/utils.torth
+++ b/compiler/utils.torth
@@ -362,7 +362,7 @@ end
 // Return: str(OpType)
 function OpType.repr int -> str :
   // Assert that every OpType has been taken into account
-  if OpType.len 28 != do
+  if OpType.len 29 != do
     "All OpTypes are not taken into account in `OpType.repr` method.\n"
     "ASSERTION_ERROR" CompilerError
   endif
@@ -397,6 +397,8 @@ function OpType.repr int -> str :
     "IF" return
   elif op_type OpType.IN == do
     "IN" return
+  elif op_type OpType.INLINE_FUNCTION_CALL == do
+    "INLINE_FUNCTION_CALL" return
   elif op_type OpType.INTRINSIC == do
     "INTRINSIC" return
   elif op_type OpType.PEEK == do

--- a/docs/keywords.md
+++ b/docs/keywords.md
@@ -245,7 +245,9 @@ INCLUDE "path/to/torth/lib/std.torth"
 INLINE keyword is used for creating inline [functions](#FUNCTION).
 
 > The inline keyword suggests that the compiler substitute the code within the function definition in place of each call to that function.
+
 > Using inline functions can make your program faster because they eliminate the overhead associated with function calls.
+
 > A tradeoff of inline functions is that the overall size of your program can increase.
 
 References:

--- a/docs/keywords.md
+++ b/docs/keywords.md
@@ -15,6 +15,7 @@ This is the documentation for different keywords available in the Torth language
 - [FUNCTION](#FUNCTION)
 - [IF](#IF)
 - [INCLUDE](#INCLUDE)
+- [INLINE](#INLINE)
 - [RETURN](#RETURN)
 - [TYPEOF](#TYPEOF)
 - [WHILE](#WHILE)
@@ -237,6 +238,24 @@ INCLUDE "std.torth"
 INCLUDE "lib/std"
 INCLUDE "lib/std.torth"
 INCLUDE "path/to/torth/lib/std.torth"
+```
+
+## INLINE
+
+INLINE keyword is used for creating inline [functions](#FUNCTION).
+
+> The inline keyword suggests that the compiler substitute the code within the function definition in place of each call to that function.
+> Using inline functions can make your program faster because they eliminate the overhead associated with function calls.
+> A tradeoff of inline functions is that the overall size of your program can increase.
+
+References:
+
+- [Inline functions in C++](https://learn.microsoft.com/en-us/cpp/cpp/inline-functions-cpp)
+
+**Syntax**
+
+```
+INLINE FUNCTION <name> <argument_types> : <function_body> END
 ```
 
 ## RETURN

--- a/editor/emacs/torth-mode.el
+++ b/editor/emacs/torth-mode.el
@@ -7,7 +7,7 @@
              ;; define several category of keywords
 	         (x-keywords '("assign" "break" "do" "done" "elif" "else" "endif" "if" "include" "while"))
 	         (x-types '("any" "bool" "char" "fn" "int" "none" "ptr" "str" "Array" "List" "LinkedList"))
-             (x-functions '("class" "const" "end" "endclass" "enum" "function" "in" "method" "peek" "return" "take"))
+             (x-functions '("class" "const" "end" "endclass" "enum" "function" "in" "inline" "method" "peek" "return" "take"))
 
 	         ;; generate regex string for each category of keywords
              (x-keywords-regexp (regexp-opt x-keywords 'words))

--- a/editor/torth.vim
+++ b/editor/torth.vim
@@ -26,7 +26,7 @@ set iskeyword=a-z,A-Z,+,-,_,*,/,=,>,<,!,:
 " Keyword tokens
 syntax keyword torthBinding CONST ENUM IN PEEK TAKE
 syntax keyword torthConditional IF ELIF ELSE ENDIF DO
-syntax keyword torthFunction CLASS END ENDCLASS FUNCTION METHOD RETURN
+syntax keyword torthFunction CLASS END ENDCLASS FUNCTION INLINE METHOD RETURN
 syntax keyword torthInclude INCLUDE
 syntax keyword torthIntrinsic AND ARGC ARGV DIV DROP DUP ENVP EXEC EQ GE GT LE LOAD_BYTE LOAD_WORD LOAD_DWORD LOAD_QWORD LT MINUS MOD MUL NE OR OVER PLUS ROT SHL SHR STORE_BYTE STORE_WORD STORE_DWORD STORE_QWORD SWAP SYSCALL0 SYSCALL1 SYSCALL2 SYSCALL3 SYSCALL4 SYSCALL5 SYSCALL6
 syntax keyword torthOperators AND OR NOT + * / = > < == != >= <= >> <<

--- a/editor/vscode/torth/syntaxes/torth.tmLanguage.json
+++ b/editor/vscode/torth/syntaxes/torth.tmLanguage.json
@@ -71,7 +71,7 @@
         },
         {
           "name": "entity.name.function.torth",
-          "match": "(?i)(?<=(class|enum|function|method)\\s)\\b(\\S+)\\b"
+          "match": "(?i)(?<=(class|enum|function|inline|method)\\s)\\b(\\S+)\\b"
         }
       ]
     },

--- a/lib/std.torth
+++ b/lib/std.torth
@@ -29,12 +29,12 @@ const mode_640 0x1a0 end
 const mode_600 0x180 end
 
 // Extra intrinsics
-function NULLPTR            -> ptr  : NULL cast(ptr)    end
-function ^        int int   -> int  : pow               end
-function not      bool      -> bool : True !=           end
-function |        int int   -> int  : or                end
-function ||       bool bool -> bool : or cast(bool)     end
-function &&       bool bool -> bool : and cast(bool)    end
+inline function NULLPTR            -> ptr  : NULL cast(ptr)    end
+inline function ^        int int   -> int  : pow               end
+inline function not      bool      -> bool : True !=           end
+inline function |        int int   -> int  : or                end
+inline function ||       bool bool -> bool : or cast(bool)     end
+inline function &&       bool bool -> bool : and cast(bool)    end
 
 // Get user input from stdin
 function input -> str :
@@ -49,17 +49,17 @@ end
 // Write a string to a file descriptor
 // Params: int fd, char *buf, size_t count
 // Return: ssize_t written_bytes
-function write int str int -> int : SYS_write syscall3 end
+inline function write int str int -> int : SYS_write syscall3 end
 
 // Read <count> bytes from a file descriptor
 // Params: int fd, char *buf, size_t count
 // Return: ssize_t read_bytes
-function read int str int -> int : SYS_read syscall3 end
+inline function read int str int -> int : SYS_read syscall3 end
 
 // Execute the command referred to by <pathname>
 // Params: const char *pathname, char *const argv[], char *const envp[]
 // Return: On success, execve does not return, on error -1 is returned
-function execve str ptr ptr -> int : SYS_execve syscall3 end
+inline function execve str ptr ptr -> int : SYS_execve syscall3 end
 
 // Exit from the program with a <status> code
 // Params: int status
@@ -91,7 +91,7 @@ end
 // Deallocate memory
 // Params: pointer (PTR), len (INT)
 // Return: None
-function munmap ptr int :
+inline function munmap ptr int :
   SYS_munmap SYSCALL2 drop
 end
 
@@ -108,37 +108,37 @@ function memcpy dest:ptr src:ptr len:int :
 end
 
 // Print a string to stdout
-function puts  str : stdout fputs end
+inline function puts  str : stdout fputs end
 
 // Print a string to stderr
-function eputs str : stderr fputs end
+inline function eputs str : stderr fputs end
 
 // Print an unsigned integer to stdout
-function putu int : itoa puts end
+inline function putu int : itoa puts end
 
 // Print an unsigned integer to stderr
-function eputu int : itoa eputs end
+inline function eputu int : itoa eputs end
 
 // Print a signed integer to stdout
-function puti int : itoa puts end
+inline function puti int : itoa puts end
 
 // Print a signed integer to stderr
-function eputi int : itoa eputs end
+inline function eputi int : itoa eputs end
 
 // Ptr functions
-function ptr+       int ptr -> ptr : swap cast(int) + cast(ptr) end
-function ptr-       int ptr -> ptr : swap cast(int) - cast(ptr) end
-function ptr++      ptr     -> ptr : ptr.size ptr+              end
-function ptr.load   ptr     -> ptr : LOAD_QWORD cast(ptr)       end
-function ptr.store  ptr ptr ->     : STORE_QWORD                end
+inline function ptr+       int ptr -> ptr : swap cast(int) + cast(ptr) end
+inline function ptr-       int ptr -> ptr : swap cast(int) - cast(ptr) end
+inline function ptr++      ptr     -> ptr : ptr.size ptr+              end
+inline function ptr.load   ptr     -> ptr : LOAD_QWORD cast(ptr)       end
+inline function ptr.store  ptr ptr ->     : STORE_QWORD                end
 
 // Bool functions
-function bool.load  ptr       -> bool : LOAD_BYTE cast(bool)    end
-function bool.store ptr bool  ->      : STORE_BYTE              end
+inline function bool.load  ptr       -> bool : LOAD_BYTE cast(bool)    end
+inline function bool.store ptr bool  ->      : STORE_BYTE              end
 
 // Char functions
-function char.load  ptr       -> char : LOAD_BYTE cast(char)    end
-function char.store ptr char  ->      : STORE_BYTE              end
+inline function char.load  ptr       -> char : LOAD_BYTE cast(char)    end
+inline function char.store ptr char  ->      : STORE_BYTE              end
 
 // Return the lowercase character for the given character
 function char.lower char -> char :
@@ -201,8 +201,8 @@ function char.to_string character:char -> str :
 end
 
 // Int functions
-function int.load     ptr       -> int    : LOAD_QWORD cast(int)  end
-function int.store    ptr int   ->        : STORE_QWORD           end
+inline function int.load     ptr       -> int    : LOAD_QWORD cast(int)  end
+inline function int.store    ptr int   ->        : STORE_QWORD           end
 
 // Get the amount of digits in an integer
 // Params: number
@@ -314,9 +314,9 @@ function atoi string:str -> int :
 end
 
 // String functions
-function str+         int str   -> str  : swap cast(int) + cast(str)    end
-function str.load     ptr       -> str  : LOAD_QWORD cast(str)          end
-function str.store    ptr str   ->      : STORE_QWORD                   end
+inline function str+         int str   -> str  : swap cast(int) + cast(str)    end
+inline function str.load     ptr       -> str  : LOAD_QWORD cast(str)          end
+inline function str.store    ptr str   ->      : STORE_QWORD                   end
 
 // Copy string to a newly allocated memory location and return the copied string
 function str.copy str -> str :
@@ -622,13 +622,13 @@ end
 // Get the character at a certain index of a string
 // Params: string, index
 // Return: character_at_index
-function str.char_at str int -> char : swap str+ cast(ptr) char.load end
+inline function str.char_at str int -> char : swap str+ cast(ptr) char.load end
 
 // Test if a string is a palindrome (reads the same backward or forward)
-function str.is_palindrome str -> bool : dup str.reverse streq end
+inline function str.is_palindrome str -> bool : dup str.reverse streq end
 
 // Test if a string is static string aka. string literal
-function str.is_static str -> bool : cast(int) KERNEL_SPACE_PTR < end
+inline function str.is_static str -> bool : cast(int) KERNEL_SPACE_PTR < end
 
 // Test if string only contains numeric characters
 function str.is_numeric string:str -> bool :
@@ -650,8 +650,8 @@ function str.is_numeric string:str -> bool :
 end
 
 // "Empty" a string by storing NULL byte to the beginning
-function str.empty string:str :
-  NULL string store_byte
+inline function str.empty str :
+  NULL swap store_byte
 end
 
 // Convert string to lowercase letters
@@ -958,7 +958,7 @@ end
 // Create a file
 // Params: const char *pathname, mode_t mode
 // Return: int fd
-function touch_file str int -> int :
+inline function touch_file str int -> int :
   SYS_creat syscall2
 end
 
@@ -995,7 +995,7 @@ end
 // Print file contents to stdout
 // Params: const char *pathname
 // Return: ssize_t written_bytes
-function print_file str :
+inline function print_file str :
   read_file puts
 end
 


### PR DESCRIPTION
Implement inline functions and mark small functions in the `std` library as `inline`.

> The inline keyword suggests that the compiler substitute the code within the function definition in place of each call to that function. In theory, using inline functions can make your program faster because they eliminate the overhead associated with function calls. Calling a function requires pushing the return address on the stack, pushing arguments onto the stack, jumping to the function body, and then executing a return instruction when the function finishes. This process is eliminated by inlining the function. ... A tradeoff of inline functions is that the overall size of your program can increase.

Ref: https://learn.microsoft.com/en-us/cpp/cpp/inline-functions-cpp