### PR TITLE
Optimize strings

### DIFF
--- a/compiler/asm.torth
+++ b/compiler/asm.torth
@@ -31,7 +31,7 @@ end
 // Get Assembly for certain Op
 function get_op_asm op:Op program:Program sub_programs:List[Program] -> str :
   // Assert that every OpType has been taken into account
-  if OpType.len 30 != do
+  if OpType.len 31 != do
     "All OpTypes are not taken into account in `get_op_asm` function.\n"
     "ASSERTION_ERROR" CompilerError
   endif
@@ -124,6 +124,9 @@ function get_op_asm op:Op program:Program sub_programs:List[Program] -> str :
     return
   elif op_type OpType.PUSH_CHAR == do
     1 token_value str.char_at get_push_char_asm
+    return
+  elif op_type OpType.PUSH_CSTR == do
+    op get_push_cstr_asm
     return
   elif op_type OpType.PUSH_FN == do
     "&" token_value str.removesuffix get_push_fn_asm
@@ -574,6 +577,14 @@ function get_push_char_asm character:char -> str :
   f"  push {character cast(int) itoa}\n"
 end
 
+// Generate Assembly for OpType.PUSH_CSTR
+// Params: Op
+// Return: Assembly
+function get_push_cstr_asm op:Op -> str :
+  f"  mov rsi, {op Op.func Func.name}_s{op Op.id itoa} ; Pointer to string
+  push rsi\n"
+end
+
 // Generate Assembly for OpType.PUSH_FN
 // Params: Op.token.value
 // Return: Assembly
@@ -999,9 +1010,9 @@ function get_string_variables_for_data_section program:Program -> str :
 
     // Add only strings to the assembly
     if
-      op Op.type OpType.PUSH_STR !=
-      op Op.type OpType.TYPEOF   !=
-      &&
+      op Op.type OpType.PUSH_CSTR   !=
+      op Op.type OpType.PUSH_STR    != &&
+      op Op.type OpType.TYPEOF      != &&
     do
       index 1 + index =
       continue
@@ -1011,7 +1022,10 @@ function get_string_variables_for_data_section program:Program -> str :
     op Op.func Func.name
     take function_name op_id in
 
-    if op Op.type OpType.PUSH_STR == do
+    if op Op.type OpType.PUSH_CSTR == do
+        "c" op Op.token Token.value str.removeprefix format_escape_sequences_for_nasm
+        take string in
+    elif op Op.type OpType.PUSH_STR == do
         op Op.token Token.value format_escape_sequences_for_nasm
         take string in
     elif op Op.type OpType.TYPEOF == do

--- a/compiler/asm.torth
+++ b/compiler/asm.torth
@@ -766,7 +766,6 @@ function get_load_asm intrinsic:str -> str :
   // "BYTE" | "WORD" | "DWORD" | "QWORD"
   "LOAD_" intrinsic str.copy str.removeprefix
   take operation_size in
-  f"{operation_size}\n" puts
 
   // Generate assembly
   "  pop rax\n"

--- a/compiler/asm.torth
+++ b/compiler/asm.torth
@@ -126,7 +126,7 @@ function get_op_asm op:Op program:Program sub_programs:List[Program] -> str :
     1 token_value str.char_at get_push_char_asm
     return
   elif op_type OpType.PUSH_CSTR == do
-    op get_push_cstr_asm
+    op get_push_str_asm
     return
   elif op_type OpType.PUSH_FN == do
     "&" token_value str.removesuffix get_push_fn_asm
@@ -577,14 +577,6 @@ function get_push_char_asm character:char -> str :
   f"  push {character cast(int) itoa}\n"
 end
 
-// Generate Assembly for OpType.PUSH_CSTR
-// Params: Op
-// Return: Assembly
-function get_push_cstr_asm op:Op -> str :
-  f"  mov rsi, {op Op.func Func.name}_s{op Op.id itoa} ; Pointer to string
-  push rsi\n"
-end
-
 // Generate Assembly for OpType.PUSH_FN
 // Params: Op.token.value
 // Return: Assembly
@@ -1020,13 +1012,16 @@ function get_string_variables_for_data_section program:Program -> str :
 
     op Op.id itoa
     op Op.func Func.name
-    take function_name op_id in
+    op Op.token Token.value
+    take token_value function_name op_id in
 
     if op Op.type OpType.PUSH_CSTR == do
-        "c" op Op.token Token.value str.removeprefix format_escape_sequences_for_nasm
+        "c" token_value str.removeprefix format_escape_sequences_for_nasm
         take string in
     elif op Op.type OpType.PUSH_STR == do
-        op Op.token Token.value format_escape_sequences_for_nasm
+        // First 8 bytes encode the string length
+        token_value str.len 2 - encode_str_variable_length
+        token_value format_escape_sequences_for_nasm str.cat
         take string in
     elif op Op.type OpType.TYPEOF == do
         op Op.stack_typeof format_escape_sequences_for_nasm
@@ -1040,6 +1035,21 @@ function get_string_variables_for_data_section program:Program -> str :
     index 1 + index =
   done
   assembly_code
+end
+
+// The first 8 bytes of `str` encode the length of the static string (little-endian)
+// Example: 4   -> "4,0,0,0,0,0,0,0,"
+// Example: 420 -> "164,1,0,0,0,0,0,0,"
+function encode_str_variable_length length:int -> str :
+    "" str.copy
+    0
+    take index buffer in
+    while index 8 < do
+        buffer length 8 index * >> 0xFF and itoa str.cat "," str.cat
+        buffer =
+        index 1 + index =
+    done
+    buffer
 end
 
 function format_escape_sequences_for_nasm string:str -> str :

--- a/compiler/asm.torth
+++ b/compiler/asm.torth
@@ -764,8 +764,9 @@ end
 function get_load_asm intrinsic:str -> str :
   // Parse operation size
   // "BYTE" | "WORD" | "DWORD" | "QWORD"
-  intrinsic str.copy str.upper "LOAD_" str.len str+
+  "LOAD_" intrinsic str.copy str.removeprefix
   take operation_size in
+  f"{operation_size}\n" puts
 
   // Generate assembly
   "  pop rax\n"

--- a/compiler/class/Signature.torth
+++ b/compiler/class/Signature.torth
@@ -19,15 +19,17 @@ class Signature
     List.init
     "" str.copy
     0
+    "->" repr str.find
     take
+      arrow_index
       index
       buffer
       param_types
       return_types
     in
 
-    while repr "->" str.startswith not do
-      0 repr str.char_at
+    while index arrow_index < do
+      index repr str.char_at
       take current_char in
 
       if current_char char.is_whitespace do
@@ -37,10 +39,11 @@ class Signature
         current_char buffer str.append buffer =
       endif
 
-      repr 1 str+ repr =
+      index 1 + index =
     done
 
-    "-> " repr str.removeprefix repr =
+    // Parse over the arrow token
+    index "-> " str.len + index =
 
     while index repr str.char_at NULL != do
       index repr str.char_at

--- a/compiler/compile.torth
+++ b/compiler/compile.torth
@@ -23,12 +23,12 @@ function compile_with_nasm out_file:str :
     object_file
   in
 
-  "nasm"      str.to_cstr cast(ptr) argv List.append
-  "-felf64"   str.to_cstr cast(ptr) argv List.append
-  "-o"        str.to_cstr cast(ptr) argv List.append
+  c"nasm"                 cast(ptr) argv List.append
+  c"-felf64"              cast(ptr) argv List.append
+  c"-o"                   cast(ptr) argv List.append
   object_file str.to_cstr cast(ptr) argv List.append
   asm_file    str.to_cstr cast(ptr) argv List.append
-  NULLPTR argv List.first "/usr/bin/nasm" str.to_cstr execve drop
+  NULLPTR argv List.first c"/usr/bin/nasm" execve drop
 end
 
 // Link object file with LD
@@ -37,13 +37,13 @@ function link_with_ld out_file:str :
   List.init // Allocate memory for arguments
   take argv object_file in
 
-  "ld"            str.to_cstr cast(ptr) argv List.append
-  "-melf_x86_64"  str.to_cstr cast(ptr) argv List.append
-  "-s"            str.to_cstr cast(ptr) argv List.append
-  "-o"            str.to_cstr cast(ptr) argv List.append
+  c"ld"                       cast(ptr) argv List.append
+  c"-melf_x86_64"             cast(ptr) argv List.append
+  c"-s"                       cast(ptr) argv List.append
+  c"-o"                       cast(ptr) argv List.append
   out_file        str.to_cstr cast(ptr) argv List.append
   object_file     str.to_cstr cast(ptr) argv List.append
-  NULLPTR argv List.first "/usr/bin/ld" str.to_cstr execve drop
+  NULLPTR argv List.first c"/usr/bin/ld" execve drop
 end
 
 // Remove files generated during compilation

--- a/compiler/compile.torth
+++ b/compiler/compile.torth
@@ -23,11 +23,11 @@ function compile_with_nasm out_file:str :
     object_file
   in
 
-  "nasm"      cast(ptr) argv List.append
-  "-felf64"   cast(ptr) argv List.append
-  "-o"        cast(ptr) argv List.append
-  object_file cast(ptr) argv List.append
-  asm_file    cast(ptr) argv List.append
+  "nasm"      str.to_cstr cast(ptr) argv List.append
+  "-felf64"   str.to_cstr cast(ptr) argv List.append
+  "-o"        str.to_cstr cast(ptr) argv List.append
+  object_file str.to_cstr cast(ptr) argv List.append
+  asm_file    str.to_cstr cast(ptr) argv List.append
   NULLPTR argv List.first "/usr/bin/nasm" str.to_cstr execve drop
 end
 
@@ -37,12 +37,12 @@ function link_with_ld out_file:str :
   List.init // Allocate memory for arguments
   take argv object_file in
 
-  "ld"            cast(ptr) argv List.append
-  "-melf_x86_64"  cast(ptr) argv List.append
-  "-s"            cast(ptr) argv List.append
-  "-o"            cast(ptr) argv List.append
-  out_file        cast(ptr) argv List.append
-  object_file     cast(ptr) argv List.append
+  "ld"            str.to_cstr cast(ptr) argv List.append
+  "-melf_x86_64"  str.to_cstr cast(ptr) argv List.append
+  "-s"            str.to_cstr cast(ptr) argv List.append
+  "-o"            str.to_cstr cast(ptr) argv List.append
+  out_file        str.to_cstr cast(ptr) argv List.append
+  object_file     str.to_cstr cast(ptr) argv List.append
   NULLPTR argv List.first "/usr/bin/ld" str.to_cstr execve drop
 end
 

--- a/compiler/compile.torth
+++ b/compiler/compile.torth
@@ -28,7 +28,7 @@ function compile_with_nasm out_file:str :
   "-o"        cast(ptr) argv List.append
   object_file cast(ptr) argv List.append
   asm_file    cast(ptr) argv List.append
-  NULLPTR argv List.first "/usr/bin/nasm" execve drop
+  NULLPTR argv List.first "/usr/bin/nasm" str.to_cstr execve drop
 end
 
 // Link object file with LD
@@ -43,7 +43,7 @@ function link_with_ld out_file:str :
   "-o"            cast(ptr) argv List.append
   out_file        cast(ptr) argv List.append
   object_file     cast(ptr) argv List.append
-  NULLPTR argv List.first "/usr/bin/ld" execve drop
+  NULLPTR argv List.first "/usr/bin/ld" str.to_cstr execve drop
 end
 
 // Remove files generated during compilation

--- a/compiler/defs.torth
+++ b/compiler/defs.torth
@@ -30,6 +30,7 @@ ENUM OpType.len 1 :
   OpType.POP_BIND
   OpType.PUSH_BIND
   OpType.PUSH_BOOL
+  OpType.PUSH_CSTR
   OpType.PUSH_CHAR
   OpType.PUSH_FN
   OpType.PUSH_INT

--- a/compiler/lex.torth
+++ b/compiler/lex.torth
@@ -433,7 +433,9 @@ function get_tokens_from_code
 
     // Double quote starts a string
     if
-      word str.len 0 ==
+      word "" streq
+      word "c" streq
+      ||
       current_char '"' ==
       &&
     do

--- a/compiler/lex.torth
+++ b/compiler/lex.torth
@@ -241,7 +241,7 @@ function get_token_type token_value:str -> str :
   // Character => 'a'
   elif
     token_value str.len 3 ==
-    token_value cast(ptr) char.load single_quote ==
+    0 token_value str.char_at single_quote ==
     2 token_value str.char_at single_quote ==
     && &&
   do
@@ -253,14 +253,14 @@ function get_token_type token_value:str -> str :
     "int" return
   // Hexadecimal => 0x1337
   elif
-    token_value cast(ptr) char.load '0' ==
+    0 token_value str.char_at '0' ==
     1 token_value str.char_at 'x' ==
     &&
   do
     "int" return
   // String => "This is string\n"
   elif
-    token_value cast(ptr) char.load                 '"' ==
+    0 token_value str.char_at '"' ==
     token_value str.len 1 - token_value str.char_at '"' ==
     &&
   do

--- a/compiler/lex.torth
+++ b/compiler/lex.torth
@@ -99,7 +99,7 @@ end
 // Return: file_with_path: str
 function get_file_name_from_path file_name:str INCLUDE_PATHS:List -> str :
   // Get the file name without quotes
-  if file_name cast(ptr) char.load '"' == do
+  if 0 file_name str.char_at '"' == do
     file_name get_string_inside_quotes
     file_name =
   endif

--- a/compiler/lex.torth
+++ b/compiler/lex.torth
@@ -166,26 +166,34 @@ end
 // Return NULL if there is no string inside quotes
 // Params: String which begins with a double quote
 // Return: The multiline string between double quotes
-function get_string_inside_quotes str -> str :
-  str.copy
-  take original in
+function get_string_inside_quotes string:str -> str :
+  string str.copy take string_copy in
 
   // Return NULL if the first character is not a double quote
-  if original cast(ptr) char.load '"' != do
+  if 0 string_copy str.char_at '"' != do
     NULLPTR cast(str) return
   endif
 
-  1 while dup original str.len < do
-    1 + // index++
-
+  string_copy str.len
+  1
+  take index string_copy_len in
+  while index string_copy_len < do
     // Return when the other quote is found
-    if dup original str.char_at '"' == do
-      original cast(ptr) over ptr+ NULL cast(char) swap char.store
-      drop
-      original 1 str+ return
+    if index string_copy str.char_at peek end_quote in '"' == do
+      // Remove the first character, the double quote
+      string_copy 1 str+ string_copy =
+
+      // Save the string length
+      index 1 - string_copy cast(ptr) int.store
+
+      // Return the string
+      string_copy return
     endif
-  done drop
-  NULLPTR cast(str)
+
+    index 1 + index =
+  done
+
+  NULLPTR cast(str) // Closing quote was not found
 end
 
 // Transfer comparison and calculations related symbols to their text counterparts

--- a/compiler/lex.torth
+++ b/compiler/lex.torth
@@ -264,6 +264,12 @@ function get_token_type token_value:str -> str :
     &&
   do
     "str" return
+  elif
+    token_value '"' "c" str.append str.startswith
+    token_value str.len 1 - token_value str.char_at '"' ==
+    &&
+  do
+    "cstr" return
   endif
   "word"
 end

--- a/compiler/lex.torth
+++ b/compiler/lex.torth
@@ -11,9 +11,9 @@ include "compiler/class/Signature"
 include "compiler/class/Variable"
 
 // Parse included files from a code string. Return the list of files.
-function get_included_files str -> List :
-  cast(ptr) List.init
-  peek included_files in List.append
+function get_included_files code_file:str -> List :
+  List.init take included_files in
+  code_file included_files List.append
 
   // Iterate over all of the new included files for this loop iteration
   0 take index in
@@ -397,7 +397,7 @@ function get_tokens_from_code
 
         // Parse the expression between curly brackets
         index 1 + index =
-        code index str+ str.copy
+        code str.len index code str.copy str.slice
         take expr in
 
         "}" expr str.find
@@ -414,7 +414,8 @@ function get_tokens_from_code
         endif
 
         // The expression ends to the close curly bracket
-        NULL expr close_curly_index str+ cast(ptr) store_byte
+        close_curly_index 0 expr str.copy str.slice
+        expr =
 
         newline_indexes index tokens file_name expr get_tokens_from_code
         newline_indexes =
@@ -891,16 +892,17 @@ function parse_function
     // Get current Token
     token_index tokens cast(List) List.nth Token.load
     dup Token.value
-    take token_value token in
+    dup str.copy str.upper
+    take token_upper token_value token in
 
-    if token_value str.copy str.upper "FUNCTION" streq do
+    if token_upper "FUNCTION" streq do
       token
       f"Token '{token_value}' is not valid inside a function"
       "SYNTAX_ERROR" CompilerErrorWithToken
     endif
 
     if
-      token_value str.copy str.upper
+      token_upper
       current_part FUNCTION_PART_DELIMITERS List.nth str.load
       streq
     do
@@ -908,7 +910,7 @@ function parse_function
       current_part =
 
       // Append Func and reset variables when function is fully lexed
-      if token_value str.copy str.upper "END" streq do
+      if token_upper "END" streq do
 
         // Append 0 token as the exit code for MAIN function
         if function_name str.copy str.upper "MAIN" streq do
@@ -960,7 +962,7 @@ function parse_function
       take param_colon in
 
       // Parse parameter's TokenType
-      token_value param_colon 1 + str+
+      token_value str.len param_colon 1 + token_value str.copy str.slice
       take param_type in
       param_type cast(ptr) param_types List.append
 
@@ -974,13 +976,8 @@ function parse_function
         endif
 
         // Parse parameter's name
-        token_value str.copy
-        dup param_colon str+ str.empty
-        token_value str.copy param_colon str+ 1 str+
-        take
-          param_type
-          param_name
-        in
+        param_colon 0 token_value str.copy str.slice
+        take param_name in
 
         // Handle function pointer parameters
         // Example => fn[str int -> bool]
@@ -1219,14 +1216,10 @@ function parse_class_attribute
     "SYNTAX_ERROR" CompilerErrorWithToken
   endif
 
-  // Parse attribute's TokenType
-  token_value attribute_colon 1 + str+
-  take attribute_type in
-
-  // Parse attribute's name
-  token_value str.copy
-  dup attribute_colon str+ str.empty
-  take attribute_name in
+  // Parse attribute's name and type
+  attribute_colon 0 token_value str.copy str.slice
+  token_value str.len attribute_colon 1 + token_value str.copy str.slice
+  take attribute_type attribute_name in
 
   // Calculate attributes byte offset from object base pointer
   attribute_count int.size *

--- a/compiler/lex.torth
+++ b/compiler/lex.torth
@@ -414,7 +414,7 @@ function get_tokens_from_code
         endif
 
         // The expression ends to the close curly bracket
-        close_curly_index 0 expr str.copy str.slice
+        close_curly_index 0 expr str.slice
         expr =
 
         newline_indexes index tokens file_name expr get_tokens_from_code

--- a/compiler/program.torth
+++ b/compiler/program.torth
@@ -122,7 +122,7 @@ function get_tokens_op_type
   constants:List[Constant]
 -> int :
   // Assert that every OpType has been taken into account
-  if OpType.len 30 != do
+  if OpType.len 31 != do
     "All OpTypes are not taken into account in `get_tokens_op_type` function.\n"
     "ASSERTION_ERROR" CompilerError
   endif
@@ -137,10 +137,12 @@ function get_tokens_op_type
     token_type
   in
 
-  if token_type "bool"        streq do
+  if token_type "bool"        streq  do
     OpType.PUSH_BOOL return
   elif token_type "char"      streq  do
     OpType.PUSH_CHAR return
+  elif token_type "cstr"      streq  do
+    OpType.PUSH_CSTR return
   elif token_type "int"       streq  do
     OpType.PUSH_INT return
   elif token_type "str"       streq  do
@@ -173,7 +175,7 @@ function get_tokens_op_type
     OpType.RETURN return
   elif token_upper "TAKE"     streq  do
     OpType.TAKE return
-  elif token_upper "TYPEOF"     streq  do
+  elif token_upper "TYPEOF"   streq  do
     OpType.TYPEOF return
   elif token_upper "WHILE"    streq  do
     OpType.WHILE return

--- a/compiler/typecheck.torth
+++ b/compiler/typecheck.torth
@@ -144,7 +144,7 @@ function type_check_op
   if_block_return_stacks:List[TypeStack]
 -> TypeCheckInfo :
   // Assert that every OpType has been taken into account
-  if OpType.len 30 != do
+  if OpType.len 31 != do
     "All OpTypes are not taken into account in `type_check_op` function.\n"
     "ASSERTION_ERROR" CompilerError
   endif
@@ -240,6 +240,9 @@ function type_check_op
     type_check_info return
   elif op_type OpType.PUSH_CHAR == do
     type_stack token type_check_push_char
+    type_check_info return
+  elif op_type OpType.PUSH_CSTR == do
+    type_stack token type_check_push_cstr
     type_check_info return
   elif op_type OpType.PUSH_FN == do
     functions type_stack token type_check_push_fn
@@ -953,6 +956,16 @@ end
 // Return None
 function type_check_push_char token:Token type_stack:Node :
   token Token.location "char" TypeNode.init cast(ptr)
+  type_stack LinkedList.push
+end
+
+// Push a c-string to the stack
+// Params
+//    token: Token
+//    type_stack: LinkedList[TypeNode]
+// Return None
+function type_check_push_cstr token:Token type_stack:Node :
+  token Token.location "cstr" TypeNode.init cast(ptr)
   type_stack LinkedList.push
 end
 

--- a/compiler/utils.torth
+++ b/compiler/utils.torth
@@ -221,13 +221,6 @@ function get_function_by_name function_name:str functions:List[Func] -> Func :
   NULL cast(Func)
 end
 
-// Get Nth command line argument
-// Params: index
-// Return: *argv[index]
-function get_nth_cmd_line_argument int -> str :
-  int.size * argv swap ptr+ cstr.load cstr.to_str
-end
-
 // Get Constant with certain name from List[Constants]
 // Params: name (STR), List[Constant]
 // Return: Constant

--- a/compiler/utils.torth
+++ b/compiler/utils.torth
@@ -61,7 +61,7 @@ function execute_program file:str :
   str.size malloc
   take argv executable in
 
-  executable argv str.store
+  executable str.to_cstr argv cstr.store
   NULLPTR argv executable str.to_cstr execve drop
 end
 
@@ -78,8 +78,8 @@ end
 function remove_file file_name:str :
   // Allocate memory for the arguments
   List.init take argv in
-  "rm"        cast(ptr) argv List.append
-  file_name   cast(ptr) argv List.append
+  "rm"        str.to_cstr cast(ptr) argv List.append
+  file_name   str.to_cstr cast(ptr) argv List.append
   NULLPTR argv List.first "/usr/bin/rm" str.to_cstr execve drop
 end
 
@@ -225,7 +225,7 @@ end
 // Params: index
 // Return: *argv[index]
 function get_nth_cmd_line_argument int -> str :
-  int.size * argv swap ptr+ str.load
+  int.size * argv swap ptr+ cstr.load cstr.to_str
 end
 
 // Get Constant with certain name from List[Constants]

--- a/compiler/utils.torth
+++ b/compiler/utils.torth
@@ -78,9 +78,9 @@ end
 function remove_file file_name:str :
   // Allocate memory for the arguments
   List.init take argv in
-  "rm"        str.to_cstr cast(ptr) argv List.append
+  c"rm"                   cast(ptr) argv List.append
   file_name   str.to_cstr cast(ptr) argv List.append
-  NULLPTR argv List.first "/usr/bin/rm" str.to_cstr execve drop
+  NULLPTR argv List.first c"/usr/bin/rm" execve drop
 end
 
 function get_location_info location:Location -> str :

--- a/compiler/utils.torth
+++ b/compiler/utils.torth
@@ -359,10 +359,10 @@ end
 
 // "cast(int)" -> "int"
 function get_cast_type token_value:str -> str :
-  token_value dup str.len 1 - str+
-  cast(ptr) NULL cast(char) swap char.store
+  token_value str.len 1 -
   "(" token_value str.find 1 +
-  token_value swap str+
+  token_value
+  str.slice
 end
 
 // Get the string representation of the OpType

--- a/compiler/utils.torth
+++ b/compiler/utils.torth
@@ -62,7 +62,7 @@ function execute_program file:str :
   take argv executable in
 
   executable argv str.store
-  NULLPTR argv executable execve drop
+  NULLPTR argv executable str.to_cstr execve drop
 end
 
 // Get prettified information for Token
@@ -80,7 +80,7 @@ function remove_file file_name:str :
   List.init take argv in
   "rm"        cast(ptr) argv List.append
   file_name   cast(ptr) argv List.append
-  NULLPTR argv List.first "/usr/bin/rm" execve drop
+  NULLPTR argv List.first "/usr/bin/rm" str.to_cstr execve drop
 end
 
 function get_location_info location:Location -> str :

--- a/compiler/utils.torth
+++ b/compiler/utils.torth
@@ -368,15 +368,14 @@ end
 // Get the string representation of the OpType
 // Params: OpType
 // Return: str(OpType)
-function OpType.repr int -> str :
+function OpType.repr op_type:int -> str :
   // Assert that every OpType has been taken into account
-  if OpType.len 30 != do
+  if OpType.len 31 != do
     "All OpTypes are not taken into account in `OpType.repr` method.\n"
     "ASSERTION_ERROR" CompilerError
   endif
 
   // Return the string representation of a certain OpType
-  take op_type in
   if op_type OpType.NONEXISTENT == do
     "NONEXISTENT" return
   elif op_type OpType.ASSIGN_BIND == do
@@ -423,6 +422,8 @@ function OpType.repr int -> str :
     "PUSH_BOOL" return
   elif op_type OpType.PUSH_CHAR == do
     "PUSH_CHAR" return
+  elif op_type OpType.PUSH_CSTR == do
+    "PUSH_CSTR" return
   elif op_type OpType.PUSH_FN == do
     "PUSH_FN" return
   elif op_type OpType.PUSH_INT == do

--- a/docs/types.md
+++ b/docs/types.md
@@ -92,9 +92,18 @@ Pointer can only be created by [casting](#casting). See `malloc` function in [st
 
 ### str - String
 
-String literals are defined with double quotes. A defined string adds a null-terminated string buffer to the `.data` section of the executable.
+A string is like a [pointer](#ptr---pointer) as it points to the beginning of the string data. The first 8 bytes of the string is the length of the string as little-endian 64-bit number. The string's characters are found after the first 8 bytes.
 
-A string is like a [pointer](#ptr---pointer) as it points to the address of the beginning of the string data.
+The string's characters are stored in char-array formation, like in C. However, the strings are not guaranteed to end with a null-byte as their length is based on the first 8 bytes. Please use [C-strings](#c-strings-cstr) when passing strings to [syscalls](./intrinsics.md#SYSCALL).
+
+String literals are defined with double quotes. A defined string literal adds a buffer to the `.data` section of the executable. The first 8 bytes of the buffer encode the string literal's length as 64-bit little-endian number, followed by the string's characters.
+
+Example generated assembly for string `"Hello, World!\n"`:
+
+```asm
+section .data
+  main_s0 db 14,0,0,0,0,0,0,0,"Hello, World!",10,"",0
+```
 
 **Note**: Modifying the string literals stored in the `.data` section could cause undefined behavior. It is recommended to create a copy of the string with the `str.copy` function from the [std](../lib/std.torth) and modifying the copied data instead of the string literal.
 
@@ -122,6 +131,20 @@ end
 
 function print_nice a:int b:int :
   f"{a b + itoa}, nice"
+end
+```
+
+#### C-strings (cstr)
+
+C-strings are null-terminated character arrays, like in C programming language. C-strings must be used with Linux syscalls instead of regular strings.
+
+C-string literals are defined like [F-strings](#f-strings) but using the letter `c`. A defined C-string adds a null-terminated string buffer to the `.data` section of the executable.
+
+Example: Hello World using only [write](https://man7.org/linux/man-pages/man2/write.2.html) syscall.
+
+```pascal
+function main :
+    14 c"Hello, World!\n" 1 1 syscall3 drop
 end
 ```
 

--- a/editor/emacs/torth-mode.el
+++ b/editor/emacs/torth-mode.el
@@ -6,7 +6,7 @@
       (let* (
              ;; define several category of keywords
 	         (x-keywords '("assign" "break" "do" "done" "elif" "else" "endif" "if" "include" "while"))
-	         (x-types '("any" "bool" "char" "fn" "int" "none" "ptr" "str" "Array" "List" "LinkedList"))
+	         (x-types '("any" "bool" "char" "cstr" "fn" "int" "none" "ptr" "str" "Array" "List" "LinkedList"))
              (x-functions '("class" "const" "end" "endclass" "enum" "function" "in" "inline" "method" "peek" "return" "take"))
 
 	         ;; generate regex string for each category of keywords

--- a/editor/torth.vim
+++ b/editor/torth.vim
@@ -54,7 +54,7 @@ syntax keyword torthNull  NULL
 syntax keyword torthBoolean TRUE FALSE
 
 " Type names the compiler recognizes
-syntax keyword torthTypeNames any bool char fn none int ptr str List Array LinkedList
+syntax keyword torthTypeNames any bool char cstr fn none int ptr str List Array LinkedList
 
 " Delimiters
 syntax match torthDelimiter /\v([:.()\[\]]|-\>|-(\D|$)@=)/  ": . ( ) [ ] ->"

--- a/editor/vscode/torth/syntaxes/torth.tmLanguage.json
+++ b/editor/vscode/torth/syntaxes/torth.tmLanguage.json
@@ -55,7 +55,7 @@
       "patterns": [
         {
           "name": "entity.name.type.torth",
-          "match": "\\(any|bool|char|fn|int|None|ptr|str|Array|List|LinkedList)\\b"
+          "match": "\\(any|bool|char|cstr|fn|int|None|ptr|str|Array|List|LinkedList)\\b"
         }
       ]
     },

--- a/lib/std.torth
+++ b/lib/std.torth
@@ -448,7 +448,6 @@ function str.copy_new string:str -> str :
   // Allocate memory which can store the string
   string str.len
   int.size + // First 8 bytes contain the string length
-  1 + // NULL byte at the end
   malloc
 
   // Fill the new memory with string content
@@ -725,7 +724,7 @@ end
 // Deallocate string's memory if it is not a string literal
 function str.delete string:str :
   if string str.is_static do return endif
-  string str.len int.size + 1 + string cast(ptr) munmap
+  string str.len int.size + string cast(ptr) munmap
 end
 
 // Append a character to the end of a string buffer

--- a/lib/std.torth
+++ b/lib/std.torth
@@ -227,6 +227,19 @@ function char.to_string character:char -> str :
   take string in
   character string str.append
 end
+function char.to_string_new character:char -> str :
+  1 peek string_len in
+  int.size + // First 8 bytes contain the string length
+  malloc cast(str)
+  take string in
+
+  // Save the string length
+  string_len string cast(ptr) int.store
+  // Save the character as the string
+  character string cast(ptr) int.size ptr+ char.store
+
+  string
+end
 
 // Int functions
 inline function int.load     ptr       -> int    : LOAD_QWORD cast(int)  end

--- a/lib/std.torth
+++ b/lib/std.torth
@@ -673,6 +673,7 @@ end
 // Params: string, index
 // Return: character_at_index
 inline function str.char_at str int -> char : swap str+ cast(ptr) char.load end
+inline function str.char_at_new str int -> char : swap str+ int.size str+ cast(ptr) char.load end
 
 // Test if a string is a palindrome (reads the same backward or forward)
 inline function str.is_palindrome str -> bool : dup str.reverse streq end

--- a/lib/std.torth
+++ b/lib/std.torth
@@ -704,6 +704,47 @@ function str.prepend string:str character:char -> str :
 
   buffer cast(str)
 end
+function str.prepend_new string:str character:char -> str :
+  // Test if the character fits in the current memory page
+  // String literals cannot be appended so them always require allocation
+  string str.len_new
+  int.size 2 +
+  take required_extra_space string_len in
+
+  // Test if the character fits in the current memory page
+  // String literals cannot be appended so them always require allocation
+  string_len PAGE_SIZE % PAGE_SIZE required_extra_space - >
+  string str.is_static ||
+  take requires_allocation in
+
+  if requires_allocation do
+    // Allocate memory for the buffer
+    string_len required_extra_space + malloc
+    take buffer in
+  else
+    string cast(ptr)
+    take buffer in
+  endif
+
+  // Add character to the beginning
+  character buffer int.size ptr+ char.store
+
+  // Copy rest of the string to the end
+  string_len
+  string str.to_cstr cast(ptr)
+  buffer int.size ptr+ 1 ptr+
+  memcpy
+
+  // Update string length
+  string_len 1 + buffer int.store
+
+  // Deallocate the original string if new memory was allocated
+  if requires_allocation do
+    string str.delete
+  endif
+
+  buffer cast(str)
+end
 
 // Get the character at a certain index of a string
 // Params: string, index

--- a/lib/std.torth
+++ b/lib/std.torth
@@ -877,6 +877,21 @@ function str.removeprefix string:str prefix:str -> str :
   endif
   string
 end
+function str.removeprefix_new string:str prefix:str -> str :
+  if string prefix str.startswith_new not do
+    string return
+  endif
+
+  string str.len_new // string_len
+  prefix str.len_new peek prefix_len in
+  minus take new_len in
+
+  // Erase the prefix by moving the string pointer
+  string prefix_len str+
+
+  // Store the new length at the first 8 bytes of the new string
+  new_len over cast(ptr) int.store
+end
 
 // Remove a suffix if it exists. Otherwise return the original string.
 // Params: string (STR), suffix (STR)

--- a/lib/std.torth
+++ b/lib/std.torth
@@ -1060,7 +1060,7 @@ function append_file filename:str buffer:str :
   // Open the file
   mode_644
   O_APPEND O_CREAT O_WRONLY | |
-  filename SYS_open syscall3
+  filename str.to_cstr SYS_open syscall3
   take fd in
 
   // Append buffer to file

--- a/lib/std.torth
+++ b/lib/std.torth
@@ -1037,9 +1037,14 @@ end
 
 // https://man7.org/linux/man-pages/man2/getcwd.2.html
 function getcwd -> str :
-    "" str.copy take cwd_buffer in
-    4096 cwd_buffer SYS_getcwd syscall2 drop
-    cwd_buffer
+    "" str.copy
+    dup str.to_cstr
+    take buffer cwd in
+    4096 buffer SYS_getcwd syscall2 drop
+
+    // Construct the string
+    buffer cstr.len cwd cast(ptr) int.store
+    cwd
 end
 
 // Get Nth command line argument

--- a/lib/std.torth
+++ b/lib/std.torth
@@ -786,6 +786,31 @@ function str.startswith prefix:str string:str -> bool :
   done
   True
 end
+function str.startswith_new prefix:str string:str -> bool :
+  // Return False if prefix.len > string.len
+  if
+    prefix str.len_new peek prefix.len in
+    string str.len_new peek string.len in
+    >
+  do
+    False return
+  endif
+
+  // Iterate characters
+  0 take index in
+  while index prefix.len < do
+    // If a character does not match, the string does not start with the prefix
+    if
+      index string str.char_at_new
+      index prefix str.char_at_new
+      !=
+    do
+      False return
+    endif
+    index 1 + index =
+  done
+  True
+end
 
 // Check if a string ends with another string
 // Params: suffix (STR), string (STR)

--- a/lib/std.torth
+++ b/lib/std.torth
@@ -686,6 +686,41 @@ function str.cat str2:str str1:str -> str :
 
   result
 end
+function str.cat_new str2:str str1:str -> str :
+  str2 str.len_new
+  str1 str.len_new
+  str1
+  take result str1.len str2.len in
+
+  str1.len int.size + PAGE_SIZE %
+  str2.len          + PAGE_SIZE >
+  str1 str.is_static ||
+  take requires_allocation in
+
+  if requires_allocation do
+    // Allocate memory to hold both string
+    str1.len str2.len + int.size + malloc
+
+    // Fill the beginning of the allocated memory with str1
+    str1 str.fill_new result =
+  endif
+
+  // Append `str2` to `str1`
+  str2.len
+  str2 str.to_cstr cast(ptr)
+  result int.size str+ str1.len str+ cast(ptr)
+  memcpy
+
+  // Update `result` string length
+  str1.len str2.len + result cast(ptr) int.store
+
+  // Deallocate `str1` new memory was allocated
+  if requires_allocation do
+    str1 str.delete
+  endif
+
+  result
+end
 
 // Deallocate string's memory if it is not a string literal
 function str.delete string:str :

--- a/lib/std.torth
+++ b/lib/std.torth
@@ -125,6 +125,7 @@ function memcpy dest:ptr src:ptr len:int :
   done
 end
 
+inline function cstr+ int cstr  -> cstr : swap cast(int) + cast(cstr) end
 function str.to_cstr string:str -> cstr :
     // Add NULL byte to the end of string
     // `str` implementation does not guarantee NULL byte in the end
@@ -976,6 +977,24 @@ function str.is_numeric string:str -> bool :
   done
   // Return True if the whole string was numeric
   string str.len 0 ==
+end
+function str.is_numeric_new string:str -> bool :
+  // Check for negative numbers
+  if string str.to_cstr peek cstring in cast(ptr) char.load '-' == do
+    cstring 1 cstr+ cstring =
+  endif
+
+  // Iterate over every character of the string
+  while cstring cast(ptr) char.load peek character in NULL != do
+    // Break if non-numeric character is found
+    if character char.is_numeric not do
+      break
+    endif
+    cstring 1 cstr+ cstring = // Point to the next character
+  done
+
+  // Return True if the whole string was numeric
+  character NULL ==
 end
 
 // "Empty" a string by storing NULL byte to the beginning

--- a/lib/std.torth
+++ b/lib/std.torth
@@ -172,7 +172,7 @@ inline function char.store ptr char  ->      : STORE_BYTE              end
 
 // Return the lowercase character for the given character
 function char.lower char -> char :
-  if dup char.is_uppercase do 32 + cast(char) endif
+  if dup char.is_uppercase do cast(int) 32 + cast(char) endif
 end
 
 // Return the uppercase character for the given character

--- a/lib/std.torth
+++ b/lib/std.torth
@@ -557,6 +557,50 @@ function str.find string:str substring:str -> int :
   // String was not found
   -1
 end
+function str.find_new string:str substring:str -> int :
+  substring str.len_new
+  string str.len_new
+  string str.copy_new
+  0
+  take
+    index
+    string_copy
+    string_len
+    substring_len
+  in
+
+  // Return -1 if substring is longer than the string
+  // or the substring is 0 length
+  if
+    substring_len string_len >
+    substring_len 0 <=
+    ||
+  do
+    -1 return
+  endif
+
+  while
+    string_copy str.len_new
+    peek string_copy_len in
+    substring_len >=
+  do
+    // String starting from the index starts with the substring
+    if string_copy substring str.startswith_new do
+      index return
+    endif
+
+    // Remove the first character from `string_copy`
+    string_copy_len 1 -
+    string_copy 1 str+
+    dup string_copy =
+    cast(ptr) int.store
+
+    index 1 + index =
+  done
+
+  // String was not found
+  -1
+end
 
 // Replace first occurrence of substring with another string.
 // Return the original string if substring is not found

--- a/lib/std.torth
+++ b/lib/std.torth
@@ -1130,9 +1130,9 @@ function sleep time:str :
   str.size 2 * malloc take argv in
 
   // execve("/usr/bin/sleep", ["sleep", "0.01"], envp)
-  "sleep" str.to_cstr argv cstr.store
+  c"sleep"            argv cstr.store
   time    str.to_cstr argv ptr.size ptr+ cstr.store
-  envp argv "/usr/bin/sleep" str.to_cstr execve drop
+  envp argv c"/usr/bin/sleep" execve drop
 end
 
 // Get the value of certain environment variable

--- a/lib/std.torth
+++ b/lib/std.torth
@@ -113,7 +113,31 @@ function memcpy dest:ptr src:ptr len:int :
   done
 end
 
+inline function cstr.load  ptr      -> cstr : LOAD_QWORD cast(cstr)   end
+inline function cstr.store ptr cstr ->      : STORE_QWORD             end
 inline function cstr+ int cstr  -> cstr : swap cast(int) + cast(cstr) end
+function cstr.to_str cstring:cstr -> str :
+    cstring cstr.len take cstring_len in
+    if cstring_len 0 == do
+        "" return
+    endif
+
+    // Allocate memory for string
+    cstring_len int.size + malloc cast(str)
+    take string in
+
+    // Save the string length
+    cstring_len string cast(ptr) int.store
+
+    // Copy the `cstring` contents to `string`
+    cstring_len
+    cstring cast(ptr)
+    string int.size str+ cast(ptr)
+    memcpy
+
+    string
+end
+
 function str.to_cstr string:str -> cstr :
     // Add NULL byte to the end of string
     // `str` implementation does not guarantee NULL byte in the end

--- a/lib/std.torth
+++ b/lib/std.torth
@@ -1018,11 +1018,12 @@ inline function print_file str :
 end
 
 // Test if a file exists
-function file_exists str -> bool :
-  O_RDONLY swap SYS_open syscall2
+function file_exists filename:str -> bool :
+  O_RDONLY filename str.to_cstr SYS_open syscall2
   take fd in
 
   if fd 0 > do
+    // Close the file descriptor
     fd SYS_close syscall1 drop
     True return
   endif

--- a/lib/std.torth
+++ b/lib/std.torth
@@ -358,6 +358,11 @@ end
 // Get the length of a string
 // Example: "Test string" -> 11
 inline function str.len str -> int : cast(ptr) int.load end
+function cstr.len string:cstr -> int :
+  0 while string over cstr+ cast(ptr) char.load NULL != do
+    1 +
+  done
+end
 
 // Fill a ptr with the contents of a string
 function str.fill string:str pointer:ptr -> str :

--- a/lib/std.torth
+++ b/lib/std.torth
@@ -125,7 +125,14 @@ function memcpy dest:ptr src:ptr len:int :
   done
 end
 
-inline function str.to_cstr str -> cstr : int.size str+ cast(cstr) end
+function str.to_cstr string:str -> cstr :
+    // Add NULL byte to the end of string
+    // `str` implementation does not guarantee NULL byte in the end
+    NULL string cast(ptr) int.size ptr+ string str.len_new ptr+ store_byte
+
+    // Return the c-style string
+    string int.size str+ cast(cstr)
+end
 
 // Print a string to stdout
 inline function puts  str : stdout fputs end

--- a/lib/std.torth
+++ b/lib/std.torth
@@ -1109,7 +1109,7 @@ function getenv evar_key:str -> str :
   // Check environment variables one by one
   0 take index in
   while envp int.load NULL != do
-    envp index ptr.size * ptr+ str.load
+    envp index ptr.size * ptr+ cstr.load cstr.to_str
     take evar_value in
 
     // Return the environment variable when found
@@ -1119,7 +1119,8 @@ function getenv evar_key:str -> str :
       done
 
       // Get the string from the character after '='
-      evar_value cast(ptr) swap 1 + ptr+ cast(str)
+      evar_value cast(ptr) swap 1 + int.size + ptr+
+      cast(cstr) cstr.to_str
       return
     endif
     index 1 + index = // index++

--- a/lib/std.torth
+++ b/lib/std.torth
@@ -904,6 +904,14 @@ function str.removesuffix string:str suffix:str -> str :
   endif
   string
 end
+function str.removesuffix_new string:str suffix:str -> str :
+  if string suffix str.endswith_new do
+    // "Remove" suffix by changing the string length
+    string str.len_new suffix str.len_new minus
+    string cast(ptr) int.store
+  endif
+  string
+end
 
 // Tests if two strings are equal
 function streq str1:str str2:str -> bool :

--- a/lib/std.torth
+++ b/lib/std.torth
@@ -632,6 +632,43 @@ function str.replace
   // Deallocate unused strings
   string_end  str.delete
 end
+function str.replace_new
+  string:str
+  substring:str
+  replacement:str
+-> str :
+  // Get the index of the first substring match
+  substring string str.find_new
+  take index in
+
+  // Return the original string if no match was found
+  if index 0 < do
+    string return
+  endif
+
+  // Store the string length
+  string str.copy_new peek string_start in
+  str.len_new index - substring str.len_new - peek end_len in
+  int.size + malloc cast(str) take string_end in
+  end_len string_end cast(ptr) int.store
+
+  // Copy the end of string from index to `string_end`
+  end_len
+  string_start int.size index + str+ cast(ptr)
+  string_end int.size str+ cast(ptr)
+  memcpy
+
+  // Update the length of the string start
+  index string_start cast(ptr) int.store
+
+  // Construct the final string
+  string_start
+  replacement str.cat_new
+  string_end  str.cat_new
+
+  // Deallocate unused strings
+  string_end str.delete
+end
 
 // Replace all occurrences of substring with another string.
 // Return the original string if substring is not found.

--- a/lib/std.torth
+++ b/lib/std.torth
@@ -966,16 +966,19 @@ function base64.encode string:str -> str :
     // Those four 6-bit numbers are used as indices into the base64 character list
     0 while dup 4 < do
       dup 6bit_list List.nth int.load base64_characters str.char_at
-      base64_string cast(ptr) base64_index ptr+ char.store
-      base64_index 1 + base64_index = // base64_index++
+      base64_string cast(ptr) int.size ptr+ base64_index ptr+ char.store
+      base64_string str.len 1 + base64_string cast(ptr) int.store
+      base64_index 1 + base64_index =
       1 +
     done drop
 
     char_index 3 + char_index = // char_index += 3
   done
 
-  // Append the padding characters and return the result
-  NULL cast(char) base64_string dup str.len padding_size - str+ cast(ptr) char.store
+  // Replace the end characters with possible padding
+  base64_string str.len padding_size - 0 base64_string str.slice
+  base64_string =
+
   if    padding_size 1 ==
   do    base64_string "="   str.cat return
   elif  padding_size 2 ==

--- a/lib/std.torth
+++ b/lib/std.torth
@@ -116,7 +116,7 @@ end
 inline function cstr.load  ptr      -> cstr : LOAD_QWORD cast(cstr)   end
 inline function cstr.store ptr cstr ->      : STORE_QWORD             end
 inline function cstr+ int cstr  -> cstr : swap cast(int) + cast(cstr) end
-function cstr.to_str cstring:cstr -> str :
+function cstr.to_string cstring:cstr -> str :
     cstring cstr.len take cstring_len in
     if cstring_len 0 == do
         "" return
@@ -1118,7 +1118,7 @@ function get_argument N:int -> str :
   endif
 
   // Convert argument to `str`
-  argv_index_ptr cstr.load cstr.to_str
+  argv_index_ptr cstr.load cstr.to_string
 end
 
 // Sleep causes the calling thread to sleep either until the
@@ -1143,7 +1143,7 @@ function getenv evar_key:str -> str :
   // Check environment variables one by one
   0 take index in
   while envp int.load NULL != do
-    envp index ptr.size * ptr+ cstr.load cstr.to_str
+    envp index ptr.size * ptr+ cstr.load cstr.to_string
     take evar_value in
 
     // Return the environment variable when found
@@ -1154,7 +1154,7 @@ function getenv evar_key:str -> str :
 
       // Get the string from the character after '='
       evar_value cast(ptr) swap 1 + int.size + ptr+
-      cast(cstr) cstr.to_str
+      cast(cstr) cstr.to_string
       return
     endif
     index 1 + index = // index++

--- a/lib/std.torth
+++ b/lib/std.torth
@@ -43,14 +43,6 @@ function input -> str :
   // Allocate memory for the user input
   MEMORY_CAPACITY malloc cast(str) take buffer in
 
-  // Read and return the user input
-  MEMORY_CAPACITY buffer stdin read drop
-  buffer
-end
-function input_new -> str :
-  // Allocate memory for the user input
-  MEMORY_CAPACITY malloc cast(str) take buffer in
-
   // Read user input
   MEMORY_CAPACITY buffer str.to_cstr stdin read
 
@@ -63,20 +55,17 @@ end
 // Write a string to a file descriptor
 // Params: int fd, char *buf, size_t count
 // Return: ssize_t written_bytes
-inline function write int str int -> int : SYS_write syscall3 end
-inline function write_new int cstr int -> int : SYS_write syscall3 end
+inline function write int cstr int -> int : SYS_write syscall3 end
 
 // Read <count> bytes from a file descriptor
 // Params: int fd, char *buf, size_t count
 // Return: ssize_t read_bytes
-inline function read int str int -> int : SYS_read syscall3 end
-inline function read_new int cstr int -> int : SYS_read syscall3 end
+inline function read int cstr int -> int : SYS_read syscall3 end
 
 // Execute the command referred to by <pathname>
 // Params: const char *pathname, char *const argv[], char *const envp[]
 // Return: On success, execve does not return, on error -1 is returned
-inline function execve str ptr ptr -> int : SYS_execve syscall3 end
-inline function execve_new cstr ptr ptr -> int : SYS_execve syscall3 end
+inline function execve cstr ptr ptr -> int : SYS_execve syscall3 end
 
 // Exit from the program with a <status> code
 // Params: int status
@@ -86,8 +75,7 @@ function exit int : SYS_exit syscall1 drop end
 // Print a string to a file descriptor
 // Params: int fd, char *buf
 // Return: None
-function fputs fd:int buf:str : buf str.len buf fd write drop end
-function fputs_new fd:int buf:str : buf str.len_new buf str.to_cstr fd write_new drop end
+function fputs fd:int buf:str : buf str.len buf str.to_cstr fd write drop end
 
 // Allocate read-write memory and return the pointer to the allocated memory
 // Params: size_t length
@@ -129,15 +117,14 @@ inline function cstr+ int cstr  -> cstr : swap cast(int) + cast(cstr) end
 function str.to_cstr string:str -> cstr :
     // Add NULL byte to the end of string
     // `str` implementation does not guarantee NULL byte in the end
-    NULL string cast(ptr) int.size ptr+ string str.len_new ptr+ store_byte
+    NULL string cast(ptr) int.size ptr+ string str.len ptr+ store_byte
 
     // Return the c-style string
     string int.size str+ cast(cstr)
 end
 
 // Print a string to stdout
-inline function puts  str : stdout fputs end
-inline function puts_new  str : stdout fputs_new end
+inline function puts str : stdout fputs end
 
 // Print a string to stderr
 inline function eputs str : stderr fputs end
@@ -150,7 +137,6 @@ inline function eputu int : itoa eputs end
 
 // Print a signed integer to stdout
 inline function puti int : itoa puts end
-inline function puti_new int : itoa_new puts_new end
 
 // Print a signed integer to stderr
 inline function eputi int : itoa eputs end
@@ -225,11 +211,6 @@ function char.is_whitespace c:char -> bool :
 end
 
 function char.to_string character:char -> str :
-  "" str.copy
-  take string in
-  character string str.append
-end
-function char.to_string_new character:char -> str :
   1 peek string_len in
   int.size + // First 8 bytes contain the string length
   malloc cast(str)
@@ -292,9 +273,9 @@ function itoa num:int -> str :
   endif
 
   // Allocate memory to the string representation
-  num int.get_digits        // digits
-  dup 2 + malloc cast(str)  // string
-  10                        // base
+  num int.get_digits
+  dup int.size + malloc cast(str)
+  10
   take
     base
     string
@@ -327,55 +308,6 @@ function itoa num:int -> str :
   // Reverse for correct processing
   string str.reverse
 end
-function itoa_new num:int -> str :
-  // Return "0" if parameter is 0
-  if num 0 == do
-    "0" return
-  endif
-
-  // Swap sign of negative number
-  num 0 < take is_negative in
-  if is_negative do
-    num int.to_positive
-    num =
-  endif
-
-  // Allocate memory to the string representation
-  num int.get_digits
-  dup int.size + malloc cast(str)
-  10
-  take
-    base
-    string
-    digits
-  in
-
-  // Process individual digits: https://www.geeksforgeeks.org/implement-itoa/
-  0 while dup digits < do
-    num base %  // rem = num/base
-
-    // str[index] = (rem > 9)? (rem-10) + 'a' : rem + '0';
-    if dup 9 >
-    do    10 - 'a' cast(int) +
-    else  '0' cast(int) +
-    endif cast(char)
-    string str.append_new
-    string =
-
-    num base / num =  // num = num/base
-    1 +               // index++
-  done drop
-
-  // Add '-' character to the end of string for negative number
-  // This will be reversed later
-  if is_negative do
-    '-' string str.append_new
-    string =
-  endif
-
-  // Reverse for correct processing
-  string str.reverse_new
-end
 
 // Get an integer representation of a string
 function atoi string:str -> int :
@@ -402,32 +334,6 @@ function atoi string:str -> int :
     integer 10 * +
     integer =
     index 1 + index = // index++
-  done integer
-end
-function atoi_new string:str -> int :
-  NULL
-  0
-  take index integer in
-
-  // Iterate the string character by character
-  while index string str.char_at_new NULL != do
-
-    // Get current character
-    index string str.char_at_new
-
-    // Raise an error if the character is not a number
-    if dup char.is_numeric not do
-      "[ERROR] atoi function failed: '"
-      string                    str.cat
-      "' is not an integer.\n"  str.cat
-      eputs 1 exit
-    endif
-
-    // Append the current character to integer
-    cast(int) '0' cast(int) -
-    integer 10 * +
-    integer =
-    index 1 + index = // index++
   done
 
   integer
@@ -439,49 +345,24 @@ inline function str.load     ptr       -> str  : LOAD_QWORD cast(str)          e
 inline function str.store    ptr str   ->      : STORE_QWORD                   end
 
 // Copy string to a newly allocated memory location and return the copied string
-function str.copy str -> str :
-  // Allocate memory which can store the string
-  dup str.len 1 + malloc
-  swap // str
-  str.fill
-end
-function str.copy_new string:str -> str :
+function str.copy string:str -> str :
   // Allocate memory which can store the string
   string str.len
   int.size + // First 8 bytes contain the string length
   malloc
 
   // Fill the new memory with string content
-  string str.fill_new
+  string str.fill
 end
 
 // Get the length of a string
 // Example: "Test string" -> 11
-function str.len string:str -> int :
-  0 while dup string str.char_at NULL != do
-    1 +
-  done
-end
-inline function str.len_new str -> int : cast(ptr) int.load end
+inline function str.len str -> int : cast(ptr) int.load end
 
 // Fill a ptr with the contents of a string
 function str.fill string:str pointer:ptr -> str :
-  // Loop through every character of the first string
-  0 take index in
-  while
-    index string str.char_at
-    peek character in
-    NULL !=
-  do
-    character
-    pointer index ptr+ char.store
-    index 1 + index =
-  done
-  pointer cast(str)
-end
-function str.fill_new string:str pointer:ptr -> str :
   // Store the string length on the first byte
-  string str.len_new peek string_len in
+  string str.len peek string_len in
   pointer int.store
 
   // Store the string content to the pointer character by character
@@ -528,40 +409,7 @@ end
 function str.find string:str substring:str -> int :
   substring str.len
   string str.len
-  0
-  take
-    index
-    string.len
-    substring.len
-  in
-
-  // Return -1 if substring is longer than the string
-  // or the substring is 0 length
-  if
-    substring.len string.len >
-    substring.len 0 <=
-    ||
-  do
-    -1 return
-  endif
-
-  while index string.len substring.len - <= do
-
-    // String starting from the index starts with the substring
-    if string index str+ substring str.startswith do
-      index return
-    endif
-
-    index 1 + index =
-  done
-
-  // String was not found
-  -1
-end
-function str.find_new string:str substring:str -> int :
-  substring str.len_new
-  string str.len_new
-  string str.copy_new
+  string str.copy
   0
   take
     index
@@ -581,12 +429,12 @@ function str.find_new string:str substring:str -> int :
   endif
 
   while
-    string_copy str.len_new
+    string_copy str.len
     peek string_copy_len in
     substring_len >=
   do
     // String starting from the index starts with the substring
-    if string_copy substring str.startswith_new do
+    if string_copy substring str.startswith do
       index return
     endif
 
@@ -605,8 +453,6 @@ end
 
 // Replace first occurrence of substring with another string.
 // Return the original string if substring is not found
-// Params: string, substring, replacement
-// Return: string
 function str.replace
   string:str
   substring:str
@@ -621,35 +467,9 @@ function str.replace
     string return
   endif
 
-  // Split the string from the index
-  string index str+ cast(ptr) NULL cast(char) swap char.store
-  string index substring str.len + str+
-  take string_end in
-
-  string str.copy
-  replacement str.cat
-  string_end  str.cat
-
-  // Deallocate unused strings
-  string_end  str.delete
-end
-function str.replace_new
-  string:str
-  substring:str
-  replacement:str
--> str :
-  // Get the index of the first substring match
-  substring string str.find_new
-  take index in
-
-  // Return the original string if no match was found
-  if index 0 < do
-    string return
-  endif
-
   // Store the string length
-  string str.copy_new peek string_start in
-  str.len_new index - substring str.len_new - peek end_len in
+  string str.copy peek string_start in
+  str.len index - substring str.len - peek end_len in
   int.size + malloc cast(str) take string_end in
   end_len string_end cast(ptr) int.store
 
@@ -664,8 +484,8 @@ function str.replace_new
 
   // Construct the final string
   string_start
-  replacement str.cat_new
-  string_end  str.cat_new
+  replacement str.cat
+  string_end  str.cat
 
   // Deallocate unused strings
   string_end str.delete
@@ -697,67 +517,14 @@ function str.replace_all
   done
   new_string
 end
-function str.replace_all_new
-  string:str
-  substring:str
-  replacement:str
--> str :
-  // Loop as long as string as occurrences of substring
-  while True do
-    // Save the current string as old_string
-    string take old_string in
-
-    // Return if str.replace does not do changes
-    replacement substring string str.replace_new
-    take new_string in
-    if new_string old_string streq do
-      new_string return
-    endif
-
-    // Use the new string in the next iteration as old_string
-    new_string string =
-  done
-  new_string
-end
 
 // Concatenate two strings. Uses existing memory page if it can store both strings.
 // Note: If the value of `str1` is still needed after `str.cat`, please copy it with `str.copy` before calling `str.cat`
 // Params: str2, str1
 // Return: concat(str1+str2)
 function str.cat str2:str str1:str -> str :
+  str2 str.len
   str1 str.len
-  str1 str.len
-  take str1.len str2.len in
-
-  str1.len 1 + PAGE_SIZE %
-  str2.len   + PAGE_SIZE >
-  str1 str.is_static ||
-  take requires_allocation in
-
-  if requires_allocation do
-    // Allocate memory to hold both string
-    str1.len str2.len + 1 + malloc
-
-    // Fill the beginning of the allocated memory with str1
-    str1 str.fill   take result in
-  else
-    str1            take result in
-  endif
-
-  // Append `str2` to `str1`
-  result str1.len str+ cast(ptr)
-  str2 str.fill drop
-
-  // Deallocate `str1` new memory was allocated
-  if requires_allocation do
-    str1 str.delete
-  endif
-
-  result
-end
-function str.cat_new str2:str str1:str -> str :
-  str2 str.len_new
-  str1 str.len_new
   str1
   take result str1.len str2.len in
 
@@ -771,7 +538,7 @@ function str.cat_new str2:str str1:str -> str :
     str1.len str2.len + int.size + malloc
 
     // Fill the beginning of the allocated memory with str1
-    str1 str.fill_new result =
+    str1 str.fill result =
   endif
 
   // Append `str2` to `str1`
@@ -798,46 +565,11 @@ function str.delete string:str :
 end
 
 // Append a character to the end of a string buffer
-// Params: string, character
-// Return: None
 function str.append string:str character:char -> str :
   // Test if the character fits in the current memory page
   // String literals cannot be appended so them always require allocation
-  string str.len PAGE_SIZE % PAGE_SIZE 2 - >
-  string str.is_static ||
-  take requires_allocation in
-
-  // Allocate memory for the string if needed
-  if requires_allocation do
-    // Allocate memory for the buffer
-    string str.len 2 + malloc
-    take buffer in
-
-    // Copy the string to buffer
-    string str.len
-    string cast(ptr)
-    buffer
-    memcpy
-  else
-    string cast(ptr)
-    take buffer in
-  endif
-
-  // Add character to the end
-  character buffer string str.len ptr+ char.store
-
-  // Deallocate the original string if new memory was allocated
-  if requires_allocation do
-    string str.delete
-  endif
-
-  buffer cast(str)
-end
-function str.append_new string:str character:char -> str :
-  // Test if the character fits in the current memory page
-  // String literals cannot be appended so them always require allocation
   int.size 2 +
-  string str.len_new
+  string str.len
   take string_len required_extra_space in
 
   string_len PAGE_SIZE % PAGE_SIZE required_extra_space - >
@@ -850,7 +582,7 @@ function str.append_new string:str character:char -> str :
     string_len required_extra_space + malloc
     peek buffer in
     // Copy the string to buffer
-    string str.fill_new drop
+    string str.fill drop
   else
     string cast(ptr)
     take buffer in
@@ -871,45 +603,10 @@ function str.append_new string:str character:char -> str :
 end
 
 // Prepend a character to the start of a string buffer
-// Params: string, character
-// Return: None
 function str.prepend string:str character:char -> str :
   // Test if the character fits in the current memory page
   // String literals cannot be appended so them always require allocation
   string str.len
-  dup PAGE_SIZE % PAGE_SIZE 2 - >
-  string str.is_static ||
-  take requires_allocation string.len in
-
-  if requires_allocation do
-    // Allocate memory for the buffer
-    string.len 2 + malloc
-    take buffer in
-  else
-    string cast(ptr)
-    take buffer in
-  endif
-
-  // Add character to the beginning
-  character buffer char.store
-
-  // Copy rest of the string to the end
-  string.len
-  string cast(ptr)
-  buffer 1 ptr+
-  memcpy
-
-  // Deallocate the original string if new memory was allocated
-  if requires_allocation do
-    string str.delete
-  endif
-
-  buffer cast(str)
-end
-function str.prepend_new string:str character:char -> str :
-  // Test if the character fits in the current memory page
-  // String literals cannot be appended so them always require allocation
-  string str.len_new
   int.size 2 +
   take required_extra_space string_len in
 
@@ -951,8 +648,7 @@ end
 // Get the character at a certain index of a string
 // Params: string, index
 // Return: character_at_index
-inline function str.char_at str int -> char : swap str+ cast(ptr) char.load end
-inline function str.char_at_new str int -> char : swap str+ int.size str+ cast(ptr) char.load end
+inline function str.char_at str int -> char : swap str+ int.size str+ cast(ptr) char.load end
 
 // Test if a string is a palindrome (reads the same backward or forward)
 inline function str.is_palindrome str -> bool : dup str.reverse streq end
@@ -962,23 +658,6 @@ inline function str.is_static str -> bool : cast(int) KERNEL_SPACE_PTR < end
 
 // Test if string only contains numeric characters
 function str.is_numeric string:str -> bool :
-  // Check for negative numbers
-  if string cast(ptr) char.load '-' == do
-    string 1 str+ string =
-  endif
-
-  // Iterate over every character of the string
-  while string cast(ptr) char.load NULL != do
-    // Break if non-numeric character is found
-    if string cast(ptr) char.load char.is_numeric not do
-      break
-    endif
-    string 1 str+ string = // Point to the next character
-  done
-  // Return True if the whole string was numeric
-  string str.len 0 ==
-end
-function str.is_numeric_new string:str -> bool :
   // Check for negative numbers
   if string str.to_cstr peek cstring in cast(ptr) char.load '-' == do
     cstring 1 cstr+ cstring =
@@ -997,34 +676,18 @@ function str.is_numeric_new string:str -> bool :
   character NULL ==
 end
 
-// "Empty" a string by storing NULL byte to the beginning
-inline function str.empty str :
-  NULL swap cast(ptr) store_byte
-end
 // "Empty" a string by making its length zero
-inline function str.empty_new string:str :
+inline function str.empty string:str :
   0 string cast(ptr) int.store
 end
 
 // Convert string to lowercase letters
 function str.lower string:str -> str :
-  string str.len  // len
-  0               // index
-  take index len in
-
-  // Rewrite string with lowercase characters
-  while index len < do
-    index string str.char_at char.lower
-    string cast(ptr) index ptr+ char.store
-    index 1 + index = // index++
-  done string
-end
-function str.lower_new string:str -> str :
-  string str.len_new
+  string str.len
   0
   take index string_len in
   while index string_len < do
-    index string str.char_at_new char.lower
+    index string str.char_at char.lower
     string int.size index + str+ cast(ptr) char.store
     index 1 + index =
   done
@@ -1034,23 +697,11 @@ end
 
 // Convert string to uppercase letters
 function str.upper string:str -> str :
-  string str.len  // len
-  0               // index
-  take index len in
-
-  // Rewrite string with uppercase characters
-  while index len < do
-    index string str.char_at char.upper
-    string cast(ptr) index ptr+ char.store
-    index 1 + index = // index++
-  done string
-end
-function str.upper_new string:str -> str :
-  string str.len_new
+  string str.len
   0
   take index string_len in
   while index string_len < do
-    index string str.char_at_new char.upper
+    index string str.char_at char.upper
     string int.size index + str+ cast(ptr) char.store
     index 1 + index =
   done
@@ -1061,7 +712,7 @@ end
 // Strip all non-alphanumeric characters from a string
 function str.alphanumeric string:str -> str :
   // Allocate enough memory to hold the whole string
-  string str.len_new
+  string str.len
   dup int.size + malloc cast(str)
   0
   take index buffer string_len in
@@ -1072,7 +723,7 @@ function str.alphanumeric string:str -> str :
 
     // Append alphanumeric character to the buffer
     if current_char char.is_alphanumeric do
-      current_char buffer str.append_new buffer =
+      current_char buffer str.append buffer =
     endif
     index 1 + index =
   done
@@ -1084,37 +735,10 @@ end
 // Params: prefix (STR), string (STR)
 // Return: True/False
 function str.startswith prefix:str string:str -> bool :
-  string str.len
-  prefix str.len
-  0
-  take
-    index
-    prefix.len
-    string.len
-  in
-
-  // Return False if prefix.len > string.len
-  if prefix.len string.len > do
-    False return
-  endif
-
-  while index prefix.len < do
-    if
-      index string str.char_at
-      index prefix str.char_at
-      !=
-    do
-      False return
-    endif
-    index 1 + index = // index++
-  done
-  True
-end
-function str.startswith_new prefix:str string:str -> bool :
   // Return False if prefix.len > string.len
   if
-    prefix str.len_new peek prefix.len in
-    string str.len_new peek string.len in
+    prefix str.len peek prefix.len in
+    string str.len peek string.len in
     >
   do
     False return
@@ -1125,8 +749,8 @@ function str.startswith_new prefix:str string:str -> bool :
   while index prefix.len < do
     // If a character does not match, the string does not start with the prefix
     if
-      index string str.char_at_new
-      index prefix str.char_at_new
+      index string str.char_at
+      index prefix str.char_at
       !=
     do
       False return
@@ -1140,37 +764,10 @@ end
 // Params: suffix (STR), string (STR)
 // Return: True/False
 function str.endswith suffix:str string:str -> bool :
-  string str.len
-  suffix str.len
-  0
-  take
-    index
-    suffix.len
-    string.len
-  in
-
-  // Return False if suffix.len > string.len
-  if suffix.len string.len > do
-    False return
-  endif
-
-  while index suffix.len < do
-    if
-      string.len index - 1 - string str.char_at
-      suffix.len index - 1 - suffix str.char_at
-      !=
-    do
-      False return
-    endif
-    index 1 + index = // index++
-  done
-  True
-end
-function str.endswith_new suffix:str string:str -> bool :
   // Return False if prefix.len > string.len
   if
-    suffix str.len_new peek suffix.len in
-    string str.len_new peek string.len in
+    suffix str.len peek suffix.len in
+    string str.len peek string.len in
     >
   do
     False return
@@ -1181,8 +778,8 @@ function str.endswith_new suffix:str string:str -> bool :
   while index suffix.len < do
     // If a character does not match, the string does not end with the prefix
     if
-      string.len index - 1 - string str.char_at_new
-      suffix.len index - 1 - suffix str.char_at_new
+      string.len index - 1 - string str.char_at
+      suffix.len index - 1 - suffix str.char_at
       !=
     do
       False return
@@ -1196,18 +793,12 @@ end
 // Params: string (STR), prefix (STR)
 // Return: None
 function str.removeprefix string:str prefix:str -> str :
-  if string prefix str.startswith do
-    string prefix str.len str+ string =
-  endif
-  string
-end
-function str.removeprefix_new string:str prefix:str -> str :
-  if string prefix str.startswith_new not do
+  if string prefix str.startswith not do
     string return
   endif
 
-  string str.len_new // string_len
-  prefix str.len_new peek prefix_len in
+  string str.len // string_len
+  prefix str.len peek prefix_len in
   minus take new_len in
 
   // Erase the prefix by moving the string pointer
@@ -1221,17 +812,9 @@ end
 // Params: string (STR), suffix (STR)
 // Return: None
 function str.removesuffix string:str suffix:str -> str :
-  // Return a new string without the matching suffix
   if string suffix str.endswith do
-    string str.copy string =
-    string dup str.len suffix str.len - str+ str.empty
-  endif
-  string
-end
-function str.removesuffix_new string:str suffix:str -> str :
-  if string suffix str.endswith_new do
     // "Remove" suffix by changing the string length
-    string str.len_new suffix str.len_new minus
+    string str.len suffix str.len minus
     string cast(ptr) int.store
   endif
   string
@@ -1257,30 +840,12 @@ function streq str1:str str2:str -> bool :
   char2 NULL ==
   &&
 end
-function streq_new str1:str str2:str -> bool :
-  // Iterate over every character of the strings
-  0 take index in
-  while
-    index str1 str.char_at_new peek char1 in NULL !=
-    index str2 str.char_at_new peek char2 in NULL !=
-    &&
-  do
-    if char1 char2 != do
-      False return
-    endif
-    index 1 + index =
-  done
-
-  // Strings are equal if both were iterated to the end
-  char1 NULL ==
-  char2 NULL ==
-  &&
-end
 
 // Reverse a string
 function str.reverse original:str -> str :
   // Allocate memory for the reversed string
-  original str.len dup malloc cast(str)
+  original str.len
+  dup int.size + malloc cast(str)
   take reversed index in
 
   // Append characters from the parameter string to allocated memory in the reversed order
@@ -1290,21 +855,6 @@ function str.reverse original:str -> str :
 
     // Append the current character to the reversed string
     reversed str.append reversed =
-  done reversed
-end
-function str.reverse_new original:str -> str :
-  // Allocate memory for the reversed string
-  original str.len_new
-  dup int.size + malloc cast(str)
-  take reversed index in
-
-  // Append characters from the parameter string to allocated memory in the reversed order
-  while 0 index < do
-    index 1 - index =           // index--
-    index original str.char_at_new  // original[index]
-
-    // Append the current character to the reversed string
-    reversed str.append_new reversed =
   done
 
   reversed

--- a/lib/std.torth
+++ b/lib/std.torth
@@ -47,21 +47,36 @@ function input -> str :
   MEMORY_CAPACITY buffer stdin read drop
   buffer
 end
+function input_new -> str :
+  // Allocate memory for the user input
+  MEMORY_CAPACITY malloc cast(str) take buffer in
+
+  // Read user input
+  MEMORY_CAPACITY buffer str.to_cstr stdin read
+
+  // Store the string length
+  buffer cast(ptr) int.store
+
+  buffer
+end
 
 // Write a string to a file descriptor
 // Params: int fd, char *buf, size_t count
 // Return: ssize_t written_bytes
 inline function write int str int -> int : SYS_write syscall3 end
+inline function write_new int cstr int -> int : SYS_write syscall3 end
 
 // Read <count> bytes from a file descriptor
 // Params: int fd, char *buf, size_t count
 // Return: ssize_t read_bytes
 inline function read int str int -> int : SYS_read syscall3 end
+inline function read_new int cstr int -> int : SYS_read syscall3 end
 
 // Execute the command referred to by <pathname>
 // Params: const char *pathname, char *const argv[], char *const envp[]
 // Return: On success, execve does not return, on error -1 is returned
 inline function execve str ptr ptr -> int : SYS_execve syscall3 end
+inline function execve_new cstr ptr ptr -> int : SYS_execve syscall3 end
 
 // Exit from the program with a <status> code
 // Params: int status
@@ -72,6 +87,7 @@ function exit int : SYS_exit syscall1 drop end
 // Params: int fd, char *buf
 // Return: None
 function fputs fd:int buf:str : buf str.len buf fd write drop end
+function fputs_new fd:int buf:str : buf str.len_new buf str.to_cstr fd write_new drop end
 
 // Allocate read-write memory and return the pointer to the allocated memory
 // Params: size_t length
@@ -109,8 +125,11 @@ function memcpy dest:ptr src:ptr len:int :
   done
 end
 
+inline function str.to_cstr str -> cstr : int.size str+ cast(cstr) end
+
 // Print a string to stdout
 inline function puts  str : stdout fputs end
+inline function puts_new  str : stdout fputs_new end
 
 // Print a string to stderr
 inline function eputs str : stderr fputs end
@@ -327,6 +346,16 @@ function str.copy str -> str :
   swap // str
   str.fill
 end
+function str.copy_new string:str -> str :
+  // Allocate memory which can store the string
+  string str.len
+  int.size + // First 8 bytes contain the string length
+  1 + // NULL byte at the end
+  malloc
+
+  // Fill the new memory with string content
+  string str.fill_new
+end
 
 // Get the length of a string
 // Example: "Test string" -> 11
@@ -335,6 +364,7 @@ function str.len string:str -> int :
     1 +
   done
 end
+inline function str.len_new str -> int : cast(ptr) int.load end
 
 // Fill a ptr with the contents of a string
 function str.fill string:str pointer:ptr -> str :
@@ -342,6 +372,24 @@ function str.fill string:str pointer:ptr -> str :
   0 take index in
   while
     index string str.char_at
+    peek character in
+    NULL !=
+  do
+    character
+    pointer index ptr+ char.store
+    index 1 + index =
+  done
+  pointer cast(str)
+end
+function str.fill_new string:str pointer:ptr -> str :
+  // Store the string length on the first byte
+  string str.len_new peek string_len in
+  pointer int.store
+
+  // Store the string content to the pointer character by character
+  int.size take index in
+  while
+    string index str+ cast(ptr) char.load
     peek character in
     NULL !=
   do

--- a/lib/std.torth
+++ b/lib/std.torth
@@ -696,6 +696,28 @@ function str.replace_all
   done
   new_string
 end
+function str.replace_all_new
+  string:str
+  substring:str
+  replacement:str
+-> str :
+  // Loop as long as string as occurrences of substring
+  while True do
+    // Save the current string as old_string
+    string take old_string in
+
+    // Return if str.replace does not do changes
+    replacement substring string str.replace_new
+    take new_string in
+    if new_string old_string streq do
+      new_string return
+    endif
+
+    // Use the new string in the next iteration as old_string
+    new_string string =
+  done
+  new_string
+end
 
 // Concatenate two strings. Uses existing memory page if it can store both strings.
 // Note: If the value of `str1` is still needed after `str.cat`, please copy it with `str.copy` before calling `str.cat`

--- a/lib/std.torth
+++ b/lib/std.torth
@@ -631,6 +631,42 @@ function str.append string:str character:char -> str :
 
   buffer cast(str)
 end
+function str.append_new string:str character:char -> str :
+  // Test if the character fits in the current memory page
+  // String literals cannot be appended so them always require allocation
+  int.size 2 +
+  string str.len_new
+  take string_len required_extra_space in
+
+  string_len PAGE_SIZE % PAGE_SIZE required_extra_space - >
+  string str.is_static ||
+  take requires_allocation in
+
+  // Allocate memory for the string if needed
+  if requires_allocation do
+    // Allocate memory for the buffer
+    string_len required_extra_space + malloc
+    peek buffer in
+    // Copy the string to buffer
+    string str.fill_new drop
+  else
+    string cast(ptr)
+    take buffer in
+  endif
+
+  // Add character to the end
+  character buffer int.size ptr+ string_len ptr+ char.store
+
+  // Update string length
+  string_len 1 + buffer int.store
+
+  // Deallocate the original string if new memory was allocated
+  if requires_allocation do
+    string str.delete
+  endif
+
+  buffer cast(str)
+end
 
 // Prepend a character to the start of a string buffer
 // Params: string, character

--- a/lib/std.torth
+++ b/lib/std.torth
@@ -1001,6 +1001,10 @@ end
 inline function str.empty str :
   NULL swap cast(ptr) store_byte
 end
+// "Empty" a string by making its length zero
+inline function str.empty_new string:str :
+  0 string cast(ptr) int.store
+end
 
 // Convert string to lowercase letters
 function str.lower string:str -> str :

--- a/lib/std.torth
+++ b/lib/std.torth
@@ -1019,6 +1019,18 @@ function str.lower string:str -> str :
     index 1 + index = // index++
   done string
 end
+function str.lower_new string:str -> str :
+  string str.len_new
+  0
+  take index string_len in
+  while index string_len < do
+    index string str.char_at_new char.lower
+    string int.size index + str+ cast(ptr) char.store
+    index 1 + index =
+  done
+
+  string
+end
 
 // Convert string to uppercase letters
 function str.upper string:str -> str :

--- a/lib/std.torth
+++ b/lib/std.torth
@@ -149,6 +149,7 @@ inline function eputu int : itoa eputs end
 
 // Print a signed integer to stdout
 inline function puti int : itoa puts end
+inline function puti_new int : itoa_new puts_new end
 
 // Print a signed integer to stderr
 inline function eputi int : itoa eputs end
@@ -325,6 +326,55 @@ function itoa num:int -> str :
   // Reverse for correct processing
   string str.reverse
 end
+function itoa_new num:int -> str :
+  // Return "0" if parameter is 0
+  if num 0 == do
+    "0" return
+  endif
+
+  // Swap sign of negative number
+  num 0 < take is_negative in
+  if is_negative do
+    num int.to_positive
+    num =
+  endif
+
+  // Allocate memory to the string representation
+  num int.get_digits
+  dup int.size + malloc cast(str)
+  10
+  take
+    base
+    string
+    digits
+  in
+
+  // Process individual digits: https://www.geeksforgeeks.org/implement-itoa/
+  0 while dup digits < do
+    num base %  // rem = num/base
+
+    // str[index] = (rem > 9)? (rem-10) + 'a' : rem + '0';
+    if dup 9 >
+    do    10 - 'a' cast(int) +
+    else  '0' cast(int) +
+    endif cast(char)
+    string str.append_new
+    string =
+
+    num base / num =  // num = num/base
+    1 +               // index++
+  done drop
+
+  // Add '-' character to the end of string for negative number
+  // This will be reversed later
+  if is_negative do
+    '-' string str.append_new
+    string =
+  endif
+
+  // Reverse for correct processing
+  string str.reverse_new
+end
 
 // Get an integer representation of a string
 function atoi string:str -> int :
@@ -352,6 +402,34 @@ function atoi string:str -> int :
     integer =
     index 1 + index = // index++
   done integer
+end
+function atoi_new string:str -> int :
+  NULL
+  0
+  take index integer in
+
+  // Iterate the string character by character
+  while index string str.char_at_new NULL != do
+
+    // Get current character
+    index string str.char_at_new
+
+    // Raise an error if the character is not a number
+    if dup char.is_numeric not do
+      "[ERROR] atoi function failed: '"
+      string                    str.cat
+      "' is not an integer.\n"  str.cat
+      eputs 1 exit
+    endif
+
+    // Append the current character to integer
+    cast(int) '0' cast(int) -
+    integer 10 * +
+    integer =
+    index 1 + index = // index++
+  done
+
+  integer
 end
 
 // String functions
@@ -1064,6 +1142,23 @@ function str.reverse original:str -> str :
     // Append the current character to the reversed string
     reversed str.append reversed =
   done reversed
+end
+function str.reverse_new original:str -> str :
+  // Allocate memory for the reversed string
+  original str.len_new
+  dup int.size + malloc cast(str)
+  take reversed index in
+
+  // Append characters from the parameter string to allocated memory in the reversed order
+  while 0 index < do
+    index 1 - index =           // index--
+    index original str.char_at_new  // original[index]
+
+    // Append the current character to the reversed string
+    reversed str.append_new reversed =
+  done
+
+  reversed
 end
 
 // https://en.wikibooks.org/wiki/Algorithm_Implementation/Miscellaneous/Base64

--- a/lib/std.torth
+++ b/lib/std.torth
@@ -504,7 +504,7 @@ function str.replace
 
   // Copy the end of string from index to `string_end`
   end_len
-  string_start int.size index + str+ cast(ptr)
+  string_start int.size index + substring str.len + str+ cast(ptr)
   string_end int.size str+ cast(ptr)
   memcpy
 

--- a/lib/std.torth
+++ b/lib/std.torth
@@ -1045,6 +1045,18 @@ function str.upper string:str -> str :
     index 1 + index = // index++
   done string
 end
+function str.upper_new string:str -> str :
+  string str.len_new
+  0
+  take index string_len in
+  while index string_len < do
+    index string str.char_at_new char.upper
+    string int.size index + str+ cast(ptr) char.store
+    index 1 + index =
+  done
+
+  string
+end
 
 // Strip all non-alphanumeric characters from a string
 function str.alphanumeric string:str -> str :

--- a/lib/std.torth
+++ b/lib/std.torth
@@ -497,40 +497,6 @@ function str.fill_new string:str pointer:ptr -> str :
   pointer cast(str)
 end
 
-// Insert a string inside another strings at certain index
-// Params: index, str2, str1
-// Return: str1[:index] + str2 + str1[index:]
-function str.insert_at
-  index:int
-  str2:str
-  str1:str
--> str :
-  if index str1 str.len >= do
-    "[ERROR] str.index_at function failed: '"
-    str1                      str.cat
-    "' does not have index "  str.cat
-    index itoa                str.cat
-    "\n"                      str.cat
-    eputs 1 exit
-  endif
-
-  // Allocate memory to hold both strings
-  str1 str.len
-  str2 str.len
-  1 + // NULL byte
-  + malloc
-  take final_str in
-
-  // Split the str2 from the index
-  str1 index str+ str.copy
-  take str1_end in
-  str1 index str+ NULL cast(char) swap cast(ptr) char.store
-
-  final_str str1 str.fill
-  str2 str.cat
-  str1_end str.cat
-end
-
 // Replace escape sequences with the corresponding characters
 // Example: "Escape newline\n" => "Escape newline<LF>"
 function str.escape string:str -> str :

--- a/lib/std.torth
+++ b/lib/std.torth
@@ -927,7 +927,7 @@ end
 // Params: int oflag, const char *path
 // Return: fd
 function open_file oflag:int path:str -> int :
-  oflag path SYS_open syscall2
+  oflag path str.to_cstr SYS_open syscall2
   take fd in
   if fd ENOENT == do
     "File '" eputs path eputs "' does not exist.\n" eputs
@@ -959,17 +959,11 @@ function read_file path:str -> str :
   take buffer fd in
 
   // Read the file to the string buffer and return it
-  MEMORY_CAPACITY buffer fd read 1 + // Include NULL byte
+  MEMORY_CAPACITY buffer str.to_cstr fd read
   take read_bytes in
 
-  // Find the size of excess memory to the closest memory page after buf
-  PAGE_SIZE read_bytes PAGE_SIZE % -
-  take offset in
-
-  MEMORY_CAPACITY read_bytes - offset -
-  take excessive_bytes in
-
-  excessive_bytes buffer cast(ptr) read_bytes offset + ptr+ munmap
+  // Save the buffer length
+  read_bytes buffer cast(ptr) int.store
 
   // Close the file descriptor
   fd SYS_close syscall1 drop

--- a/lib/std.torth
+++ b/lib/std.torth
@@ -933,6 +933,25 @@ function streq str1:str str2:str -> bool :
   char2 NULL ==
   &&
 end
+function streq_new str1:str str2:str -> bool :
+  // Iterate over every character of the strings
+  0 take index in
+  while
+    index str1 str.char_at_new peek char1 in NULL !=
+    index str2 str.char_at_new peek char2 in NULL !=
+    &&
+  do
+    if char1 char2 != do
+      False return
+    endif
+    index 1 + index =
+  done
+
+  // Strings are equal if both were iterated to the end
+  char1 NULL ==
+  char2 NULL ==
+  &&
+end
 
 // Reverse a string
 function str.reverse original:str -> str :

--- a/lib/std.torth
+++ b/lib/std.torth
@@ -547,6 +547,29 @@ function str.replace_all
   new_string
 end
 
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice
+// Get slice from string, does not copy
+function str.slice string:str start_index:int end_index:int -> str :
+    // Return empty string when `start_index` does not make sense
+    if
+        start_index end_index >=
+        start_index string str.len peek string_len in >=
+        ||
+    do
+        "" return
+    endif
+
+    // Use the string length as the end index when `end_index` is too large
+    if end_index string_len >= do
+        string_len end_index =
+    endif
+
+    // Construct the new string
+    string start_index str+ string =
+    end_index start_index - string cast(ptr) int.store
+    string
+end
+
 // Concatenate two strings. Uses existing memory page if it can store both strings.
 // Note: If the value of `str1` is still needed after `str.cat`, please copy it with `str.copy` before calling `str.cat`
 // Params: str2, str1

--- a/lib/std.torth
+++ b/lib/std.torth
@@ -1060,10 +1060,9 @@ end
 
 // Strip all non-alphanumeric characters from a string
 function str.alphanumeric string:str -> str :
-
   // Allocate enough memory to hold the whole string
-  string str.len
-  dup malloc cast(str)
+  string str.len_new
+  dup int.size + malloc cast(str)
   0
   take index buffer string_len in
 
@@ -1073,7 +1072,7 @@ function str.alphanumeric string:str -> str :
 
     // Append alphanumeric character to the buffer
     if current_char char.is_alphanumeric do
-      current_char buffer str.append buffer =
+      current_char buffer str.append_new buffer =
     endif
     index 1 + index =
   done

--- a/lib/std.torth
+++ b/lib/std.torth
@@ -698,9 +698,17 @@ function str.prepend string:str character:char -> str :
 end
 
 // Get the character at a certain index of a string
-// Params: string, index
-// Return: character_at_index
-inline function str.char_at str int -> char : swap str+ int.size str+ cast(ptr) char.load end
+// Return NULL if index is not within the string
+function str.char_at string:str index:int -> char :
+    if
+        index string str.len >=
+        index 0 <
+        ||
+    do
+        NULL cast(char) return
+    endif
+    string int.size str+ index str+ cast(ptr) char.load
+end
 
 // Test if a string is a palindrome (reads the same backward or forward)
 inline function str.is_palindrome str -> bool : dup str.reverse streq end

--- a/lib/std.torth
+++ b/lib/std.torth
@@ -1090,17 +1090,15 @@ end
 // Sleep causes the calling thread to sleep either until the
 // number of real-time seconds specified in parameters have elapsed or
 // until a signal arrives which is not ignored.
-// Params: How many seconds to sleep (STR)
-// Return: None
 // Usage: "4.2" sleep  // Sleep for 4.2 seconds
-function sleep str :
+function sleep time:str :
   // Allocate memory for two strings
   str.size 2 * malloc take argv in
 
   // execve("/usr/bin/sleep", ["sleep", "0.01"], envp)
-  "sleep" argv str.store
-  argv ptr.size ptr+ str.store
-  envp argv "/usr/bin/sleep" execve drop
+  "sleep" str.to_cstr argv cstr.store
+  time    str.to_cstr argv ptr.size ptr+ cstr.store
+  envp argv "/usr/bin/sleep" str.to_cstr execve drop
 end
 
 // Get the value of certain environment variable

--- a/lib/std.torth
+++ b/lib/std.torth
@@ -1072,10 +1072,19 @@ function getcwd -> str :
 end
 
 // Get Nth command line argument
+// Return NULL if Nth argument is not found
 // Params: index
 // Return: *argv[index]
-function get_argument int -> str :
-  int.size * argv swap ptr+ str.load
+function get_argument N:int -> str :
+  argv int.size N * ptr+
+  take argv_index_ptr in
+
+  if argv_index_ptr int.load 0 == do
+    NULL cast(str) return
+  endif
+
+  // Convert argument to `str`
+  argv_index_ptr cstr.load cstr.to_str
 end
 
 // Sleep causes the calling thread to sleep either until the

--- a/lib/std.torth
+++ b/lib/std.torth
@@ -976,7 +976,7 @@ end
 // Params: const char *pathname, mode_t mode
 // Return: int fd
 inline function touch_file str int -> int :
-  SYS_creat syscall2
+  str.to_cstr SYS_creat syscall2
 end
 
 // Write a string to a file

--- a/lib/std.torth
+++ b/lib/std.torth
@@ -796,7 +796,7 @@ function str.startswith_new prefix:str string:str -> bool :
     False return
   endif
 
-  // Iterate characters
+  // Iterate characters from the start
   0 take index in
   while index prefix.len < do
     // If a character does not match, the string does not start with the prefix
@@ -839,6 +839,31 @@ function str.endswith suffix:str string:str -> bool :
       False return
     endif
     index 1 + index = // index++
+  done
+  True
+end
+function str.endswith_new suffix:str string:str -> bool :
+  // Return False if prefix.len > string.len
+  if
+    suffix str.len_new peek suffix.len in
+    string str.len_new peek string.len in
+    >
+  do
+    False return
+  endif
+
+  // Iterate characters from the end
+  0 take index in
+  while index suffix.len < do
+    // If a character does not match, the string does not end with the prefix
+    if
+      string.len index - 1 - string str.char_at_new
+      suffix.len index - 1 - suffix str.char_at_new
+      !=
+    do
+      False return
+    endif
+    index 1 + index =
   done
   True
 end

--- a/lib/std.torth
+++ b/lib/std.torth
@@ -592,7 +592,7 @@ end
 // Deallocate string's memory if it is not a string literal
 function str.delete string:str :
   if string str.is_static do return endif
-  string str.len 1 + string cast(ptr) munmap
+  string str.len int.size + 1 + string cast(ptr) munmap
 end
 
 // Append a character to the end of a string buffer

--- a/lib/std.torth
+++ b/lib/std.torth
@@ -989,21 +989,22 @@ function write_file str int str -> int :
   // Write to the file
   take fd buf in
   buf str.len // size_t count
-  buf fd SYS_write syscall3
+  buf str.to_cstr fd SYS_write syscall3
 
   // Close the file descriptor
   fd SYS_close syscall1 drop
 end
 
 // Params: const char *filename, const void *buf
-function append_file str str :
+function append_file filename:str buffer:str :
+  // Open the file
   mode_644
   O_APPEND O_CREAT O_WRONLY | |
-  rot SYS_open syscall3
+  filename SYS_open syscall3
+  take fd in
 
-  take fd buf in
-  buf str.len // size_t count
-  buf fd SYS_write syscall3 drop
+  // Append buffer to file
+  buffer str.len buffer str.to_cstr fd SYS_write syscall3 drop
 
   // Close the file descriptor
   fd SYS_close syscall1 drop


### PR DESCRIPTION
This PR changes how the strings are encoded in Torth. Previously, `str` type was a null-terminated character array, like in C. After this PR, the first 8 bytes of the `str` type store the string length, followed by the character array. The new `str` implementation **does not** guarantee that a string ends with a null-byte. Thus, whenever C-like string is needed, one should use C-strings (`cstr`). `str` can be transformed to `cstr` using the `str.to_cstr` function from the `std` library.

**NOTE**: All code that performs pointer arithmetic with strings will be broken after this PR — the examples, libraries, etc. will be fixed afterwards.

### Changes

- Change `str` implementation
- Introduce `cstr` type
- Introduce `cstr` literal syntax: `c"This is C-string"`
- New OpType for Torth IR: `OpType.PUSH_CSTR`
- Introduce new functions to `std` library
  - cstr.load
  - cstr.store
  - cstr+
  - cstr.to_string
  - cstr.len
  - str.to_cstr
  - str.slice
- Remove unused functions from `std` library
  - str.index_at