### PR TITLE
Reimplement `malloc` using built-in `ArenaAllocator`

### DIFF
--- a/compiler/asm.torth
+++ b/compiler/asm.torth
@@ -997,7 +997,6 @@ function generate_assembly_file
 
   // Append .data section to the assembly file
   data_section_asm file_name append_file
-  data_section_asm str.delete
 end
 
 // Get Assembly code to be added to .data section from Program's string variables
@@ -1093,8 +1092,6 @@ function format_escape_sequences_for_nasm string:str -> str :
 
   DoubleQuote str.copy ",27," str.cat DoubleQuote str.cat
   Escape string str.replace_all
-
-  DoubleQuote str.delete
 end
 
 // Pop a value from the data stack and push it to the return stack

--- a/compiler/asm.torth
+++ b/compiler/asm.torth
@@ -23,6 +23,7 @@ function get_asm_file_start -> str :
 
 section .bss
   args_ptr: resq 1
+  arena_allocator: resq 3
   return_stack: resb 1337*64
 
 "
@@ -164,6 +165,8 @@ function get_intrinsic_asm token:Token -> str :
   take intrinsic in
   if intrinsic "AND" streq do
     get_and_asm return
+  elif intrinsic "ARENA" streq do
+    get_arena_asm return
   elif intrinsic "ARGC" streq do
     get_argc_asm return
   elif intrinsic "ARGV" streq do
@@ -657,6 +660,13 @@ end
 function get_and_asm -> str :
   "  pop rax
   and [rsp], rax\n"
+end
+
+// ARENA pushes built-in ArenaAllocator to the stack
+// Params: None
+// Return: Assembly
+function get_arena_asm -> str :
+  "  push arena_allocator"
 end
 
 // ARGC pushes the argument count to the stack

--- a/compiler/class/Token.torth
+++ b/compiler/class/Token.torth
@@ -20,8 +20,4 @@ class Token
   method load ptr -> Token :
     ptr.load cast(Token)
   end
-
-  method delete self:Token :
-    Token.size self cast(ptr) munmap
-  end
 endclass

--- a/compiler/lex.torth
+++ b/compiler/lex.torth
@@ -944,7 +944,6 @@ function parse_function
       if token_value ":" streq do
         current_part 2 + current_part =
         token_index 1 + token_index =
-        token_value str.delete
         continue
       endif
 

--- a/compiler/program.torth
+++ b/compiler/program.torth
@@ -225,6 +225,7 @@ function get_tokens_op_type
   // Intrinsics
   elif
     token_upper "AND"         streq
+    token_upper "ARENA"       streq ||
     token_upper "ARGC"        streq ||
     token_upper "ARGV"        streq ||
     token_upper "DIV"         streq ||

--- a/compiler/typecheck.torth
+++ b/compiler/typecheck.torth
@@ -301,7 +301,9 @@ function type_check_intrinsic
   take intrinsic in
 
   // Switch like if block with every type of Intrinsic
-  if intrinsic "ARGC" streq do
+  if intrinsic "ARENA" streq do
+    type_stack token type_check_push_arena_allocator return
+  elif intrinsic "ARGC" streq do
     type_stack token type_check_push_int return
   elif intrinsic "ARGV" streq do
     type_stack token type_check_push_ptr return
@@ -937,6 +939,16 @@ function type_check_push_bind
   token Token.location
   token Token.value variables List.get_variable Variable.type
   TypeNode.init cast(ptr) type_stack LinkedList.push
+end
+
+// Push built-in ArenaAllocator to the stack
+// Params
+//    token: Token
+//    type_stack: LinkedList[TypeNode]
+// Return None
+function type_check_push_arena_allocator token:Token type_stack:Node :
+  token Token.location "ArenaAllocator" TypeNode.init cast(ptr)
+  type_stack LinkedList.push
 end
 
 // Push a boolean to the stack

--- a/compiler/typecheck.torth
+++ b/compiler/typecheck.torth
@@ -115,10 +115,6 @@ function type_check_sub_program
   branched_stacks List.last Node.load
   peek node in
   func type_check_end_of_program
-
-  // Deallocate branched stacks
-  TypeNode.size node LinkedList.delete
-  branched_stacks List.delete
 end
 
 // Type check the current Op in the Program
@@ -433,9 +429,6 @@ function correct_return_types func:Func type_stack:Node -> bool :
     index 1 + index =
   done
   type_stack temp_stack equal_stacks
-
-  // Clean memory from the temporary stack
-  TypeNode.size temp_stack LinkedList.delete
 end
 
 // Check if two TypeStacks have similar types inside
@@ -588,9 +581,6 @@ function type_check_assign_bind
     variable_type             str.cat
     "VALUE_ERROR" CompilerErrorWithStack
   endif
-
-  // Clean memory from the temporary stack
-  TypeNode.size temp_stack LinkedList.delete
 end
 
 // CAST(<type>) explicitely casts the top element of the stack to <type>
@@ -643,9 +633,6 @@ function type_check_do
   endif
 
   type_stack TypeStack.copy branched_stacks List.append
-
-  // Clean memory from the temporary stack
-  TypeNode.size temp_stack LinkedList.delete
 end
 
 // Type check ELIF section of an IF block
@@ -836,9 +823,6 @@ function type_check_function_call
     type_stack LinkedList.push
     index 1 + index =
   done
-
-  // Clean memory from the temporary stack
-  TypeNode.size temp_stack LinkedList.delete
 end
 
 // Push a function pointer to the stack
@@ -895,9 +879,6 @@ function type_check_peek_bind
   // Save the popped type to the Variable
   type TypeNode.type token Token.value Variable.init
   variables cast(List) List.append
-
-  // Clean memory from the temporary stack
-  TypeNode.size temp_stack LinkedList.delete
 end
 
 // Pop a value from the stack to a Variable
@@ -1109,9 +1090,6 @@ function type_check_div token:Token type_stack:Node :
   token Token.location
   take location in
   location "int" TypeNode.init cast(ptr) type_stack LinkedList.push
-
-  // Clean memory from the temporary stack
-  TypeNode.size temp_stack LinkedList.delete
 end
 
 // DROP removes one item from the stack
@@ -1238,9 +1216,6 @@ function type_check_exec token:Token type_stack:Node :
 
     index 1 + index =
   done
-
-  // Clean memory from the temporary stack
-  TypeNode.size temp_stack LinkedList.delete
 end
 
 function parse_signature_from_fn_ptr fn_ptr:str -> Signature :
@@ -1282,9 +1257,6 @@ function type_check_load token:Token type_stack:Node :
   // Push loaded value which could be of any type
   token Token.location "any" TypeNode.init cast(ptr)
   type_stack LinkedList.push
-
-  // Clean memory from the temporary stack
-  TypeNode.size temp_stack LinkedList.delete
 end
 
 // OVER Intrinsic pushes a copy of the second element of the stack.
@@ -1311,9 +1283,6 @@ function type_check_over token:Token type_stack:Node :
   t2 cast(ptr) type_stack LinkedList.push
   t1 cast(ptr) type_stack LinkedList.push
   t2 cast(ptr) type_stack LinkedList.push
-
-  // Clean memory from the temporary stack
-  TypeNode.size temp_stack LinkedList.delete
 end
 
 // ROT Intrinsic rotates the top three elements of the stack so that the third becomes first
@@ -1341,9 +1310,6 @@ function type_check_rot token:Token type_stack:Node :
   t2 cast(ptr) type_stack LinkedList.push
   t1 cast(ptr) type_stack LinkedList.push
   t3 cast(ptr) type_stack LinkedList.push
-
-  // Clean memory from the temporary stack
-  TypeNode.size temp_stack LinkedList.delete
 end
 
 // STORE variants store a value of certain type to where a pointer is pointing to.
@@ -1374,9 +1340,6 @@ function type_check_store token:Token type_stack:Node :
     f"The first argument of {intrinsic} intrinsic should be 'ptr' but got '{t1 TypeNode.type}'"
     "VALUE_ERROR" CompilerErrorWithStack
   endif
-
-  // Clean memory from the temporary stack
-  TypeNode.size temp_stack LinkedList.delete
 end
 
 // SWAP Intrinsic swaps two top elements in the stack.
@@ -1402,9 +1365,6 @@ function type_check_swap token:Token type_stack:Node :
   // Push the values back to the stack in the correct order
   t1 cast(ptr) type_stack LinkedList.push
   t2 cast(ptr) type_stack LinkedList.push
-
-  // Clean memory from the temporary stack
-  TypeNode.size temp_stack LinkedList.delete
 end
 
 // SYSCALL intrinsic variants call a Linux syscall.
@@ -1477,9 +1437,6 @@ function type_check_syscall token:Token type_stack:Node :
   // Push syscall return code to the stack
   token Token.location "int" TypeNode.init cast(ptr)
   type_stack LinkedList.push
-
-  // Clean memory from the temporary stack
-  TypeNode.size temp_stack LinkedList.delete
 end
 
 // Type check bitwise operation for two integers
@@ -1506,9 +1463,6 @@ function type_check_bitwise token:Token type_stack:Node :
   // Push the result to the stack
   token Token.location "int" TypeNode.init cast(ptr)
   type_stack LinkedList.push
-
-  // Clean memory from the temporary stack
-  TypeNode.size temp_stack LinkedList.delete
 end
 
 // SHL performs bitshift operations to the left SHR to the right.
@@ -1547,9 +1501,6 @@ function type_check_bitshift token:Token type_stack:Node :
   // Push the result to the stack
   token Token.location "int" TypeNode.init cast(ptr)
   type_stack LinkedList.push
-
-  // Clean memory from the temporary stack
-  TypeNode.size temp_stack LinkedList.delete
 end
 
 // Type check calculation intrinsics DIV, MINUS, MOD, MUL, and PLUS
@@ -1587,9 +1538,6 @@ function type_check_calculations token:Token type_stack:Node :
   // Push the result to the stack
   token Token.location "int" TypeNode.init cast(ptr)
   type_stack LinkedList.push
-
-  // Clean memory from the temporary stack
-  TypeNode.size temp_stack LinkedList.delete
 end
 
 // Type check comparison intrinsics like EQ or GE.
@@ -1618,9 +1566,6 @@ function type_check_comparison token:Token type_stack:Node :
   // Push the result to the stack
   token Token.location "bool" TypeNode.init cast(ptr)
   type_stack LinkedList.push
-
-  // Clean memory from the temporary stack
-  TypeNode.size temp_stack LinkedList.delete
 end
 
 // Get a list of tokens that do not require type checking

--- a/lib/std.torth
+++ b/lib/std.torth
@@ -515,9 +515,6 @@ function str.replace
   string_start
   replacement str.cat
   string_end  str.cat
-
-  // Deallocate unused strings
-  string_end str.delete
 end
 
 // Replace all occurrences of substring with another string.
@@ -602,18 +599,7 @@ function str.cat str2:str str1:str -> str :
   // Update `result` string length
   str1.len str2.len + result cast(ptr) int.store
 
-  // Deallocate `str1` new memory was allocated
-  if requires_allocation do
-    str1 str.delete
-  endif
-
   result
-end
-
-// Deallocate string's memory if it is not a string literal
-function str.delete string:str :
-  if string str.is_static do return endif
-  string str.len int.size + string cast(ptr) munmap
 end
 
 // Append a character to the end of a string buffer
@@ -645,11 +631,6 @@ function str.append string:str character:char -> str :
 
   // Update string length
   string_len 1 + buffer int.store
-
-  // Deallocate the original string if new memory was allocated
-  if requires_allocation do
-    string str.delete
-  endif
 
   buffer cast(str)
 end
@@ -688,11 +669,6 @@ function str.prepend string:str character:char -> str :
 
   // Update string length
   string_len 1 + buffer int.store
-
-  // Deallocate the original string if new memory was allocated
-  if requires_allocation do
-    string str.delete
-  endif
 
   buffer cast(str)
 end

--- a/lib/std.torth
+++ b/lib/std.torth
@@ -19,6 +19,11 @@ const stdin  0 end
 const stdout 1 end
 const stderr 2 end
 
+// `file_stat` struct offsets
+// https://stackoverflow.com/questions/27216616/get-file-size-with-stat-syscall
+const file_stat.len 144 end
+const file_stat.st_size 48 end
+
 // Usual file modes
 const mode_777 0x1ff end
 const mode_755 0x1ed end
@@ -990,6 +995,13 @@ function open_file oflag:int path:str -> int :
   fd
 end
 
+function fd.size fd:int -> int :
+    file_stat.len malloc peek file_stat_buffer in
+    fd SYS_fstat syscall2 drop
+
+    file_stat_buffer file_stat.st_size ptr+ int.load
+end
+
 // Read a file to a newly allocated memory
 // Params: const char *path
 // Return: str buffer
@@ -999,11 +1011,14 @@ function read_file path:str -> str :
   path O_RDONLY open_file
 
   // Allocate string buffer
-  MEMORY_CAPACITY malloc cast(str)
+  dup fd.size peek fd_size in
+  int.size +    // First 8 bytes contain the string length
+  1 +           // NULL byte
+  malloc cast(str)
   take buffer fd in
 
   // Read the file to the string buffer and return it
-  MEMORY_CAPACITY buffer str.to_cstr fd read
+  fd_size buffer str.to_cstr fd read
   take read_bytes in
 
   // Save the buffer length

--- a/lib/std.torth
+++ b/lib/std.torth
@@ -1214,18 +1214,18 @@ const ARENA_REGION_MIN_CAPACITY 4064 end
 // Minimum space left to not update the `current` region
 const ARENA_CURRENT_MIN_SPACE 128 end
 
-class Arena
+class ArenaAllocator
     first:ArenaRegion   // First region of the arena
     current:ArenaRegion // Currently used region
     last:ArenaRegion    // Last region in the arena
 
-    method init capacity:int -> Arena :
-        Arena.size malloc cast(Arena)
+    method init capacity:int -> ArenaAllocator :
+        ArenaAllocator.size malloc cast(ArenaAllocator)
     end
 
     // Find region with enough space from the arena or allocate one
-    method find_region self:Arena bytes:int -> ArenaRegion :
-        self Arena.current take region in
+    method find_region self:ArenaAllocator bytes:int -> ArenaRegion :
+        self ArenaAllocator.current take region in
         while region NULL != do
             // Region with enough leftover capacity is found
             if region ArenaRegion.capacity region ArenaRegion.count bytes + >= do
@@ -1236,13 +1236,13 @@ class Arena
 
         // Append a new region to the end of the arena
         bytes ArenaRegion.init
-        dup self Arena.append_region
+        dup self ArenaAllocator.append_region
     end
 
-    // Allocate `bytes` for Arena
-    method allocate self:Arena bytes:int -> ptr :
+    // Allocate `bytes` for ArenaAllocator
+    method allocate self:ArenaAllocator bytes:int -> ptr :
         // Find region with enough free space
-        bytes self Arena.find_region take region in
+        bytes self ArenaAllocator.find_region take region in
 
         // Get pointer to the allocated chunk, this will be returned
         region ArenaRegion.data region ArenaRegion.count ptr+
@@ -1253,45 +1253,45 @@ class Arena
         // Update `current` if it has less than `ARENA_CURRENT_MIN_SPACE` bytes left
         if
             ARENA_CURRENT_MIN_SPACE
-            self Arena.current peek current in
+            self ArenaAllocator.current peek current in
             ArenaRegion.capacity current ArenaRegion.count -
             >
         do
-            ARENA_CURRENT_MIN_SPACE self Arena.find_region
-            self Arena->current
+            ARENA_CURRENT_MIN_SPACE self ArenaAllocator.find_region
+            self ArenaAllocator->current
         endif
     end
 
-    // Append region to the end of the Arena
-    method append_region self:Arena region:ArenaRegion :
-        self Arena.first cast(int) puti " arst\n" puts
-        if self Arena.first NULL == do
-            region self Arena->first
-            region self Arena->current
+    // Append region to the end of the ArenaAllocator
+    method append_region self:ArenaAllocator region:ArenaRegion :
+        self ArenaAllocator.first cast(int) puti " arst\n" puts
+        if self ArenaAllocator.first NULL == do
+            region self ArenaAllocator->first
+            region self ArenaAllocator->current
         else
-            region self Arena.last ArenaRegion->next
+            region self ArenaAllocator.last ArenaRegion->next
         endif
-        region self Arena->last
+        region self ArenaAllocator->last
     end
 
     // Reset the arena without deallocating its regions
-    method reset self:Arena :
+    method reset self:ArenaAllocator :
         // Zero counts for regions
-        self Arena.first take region in
+        self ArenaAllocator.first take region in
         while region NULL != do
             0 region ArenaRegion->count
             region ArenaRegion.next region =
         done
 
         // Reset `current` and `last`
-        self Arena.first self Arena->current
-        self Arena.first self Arena->last
+        self ArenaAllocator.first self ArenaAllocator->current
+        self ArenaAllocator.first self ArenaAllocator->last
     end
 
     // Deallocating the arena with its regions
-    method delete self:Arena :
+    method delete self:ArenaAllocator :
         // Deallocate regions
-        self Arena.first take region in
+        self ArenaAllocator.first take region in
         while region NULL != do
             region ArenaRegion.next take next in
             region ArenaRegion.delete
@@ -1299,7 +1299,7 @@ class Arena
         done
 
         // Deallocate arena
-        Arena.size self cast(ptr) munmap
+        ArenaAllocator.size self cast(ptr) munmap
     end
 endclass
 

--- a/lib/std.torth
+++ b/lib/std.torth
@@ -1214,7 +1214,7 @@ class ArenaAllocator
     current:ArenaRegion // Currently used region
     last:ArenaRegion    // Last region in the arena
 
-    method init capacity:int -> ArenaAllocator :
+    method init -> ArenaAllocator :
         ArenaAllocator.size mmap cast(ArenaAllocator)
     end
 

--- a/lib/std.torth
+++ b/lib/std.torth
@@ -1286,7 +1286,7 @@ class ArenaAllocator
         self ArenaAllocator.first self ArenaAllocator->last
     end
 
-    // Deallocating the arena with its regions
+    // Deallocating regions within the arena
     method delete self:ArenaAllocator :
         // Deallocate regions
         self ArenaAllocator.first take region in
@@ -1295,6 +1295,14 @@ class ArenaAllocator
             region ArenaRegion.delete
             next region =
         done
+
+        // Built-in arena cannot be deallocated so reset it instead
+        if self KERNEL_SPACE_PTR < do
+            NULL cast(ArenaRegion) self ArenaAllocator->first
+            NULL cast(ArenaRegion) self ArenaAllocator->current
+            NULL cast(ArenaRegion) self ArenaAllocator->last
+            return
+        endif
 
         // Deallocate arena
         ArenaAllocator.size self cast(ptr) munmap

--- a/lib/std.torth
+++ b/lib/std.torth
@@ -4,9 +4,6 @@
 // Common constants
 const NULL 0 end
 
-// Memory
-const MEMORY_CAPACITY 430080 end  // 420 * 1024 => 420kb
-
 // Data types
 const bool.size   1 end
 const char.size   1 end
@@ -44,12 +41,12 @@ inline function <<       int int   -> int  : shl               end
 inline function >>       int int   -> int  : shr               end
 
 // Get user input from stdin
-function input -> str :
+function input max_length:int -> str :
   // Allocate memory for the user input
-  MEMORY_CAPACITY malloc cast(str) take buffer in
+  max_length malloc cast(str) take buffer in
 
   // Read user input
-  MEMORY_CAPACITY buffer str.to_cstr stdin read
+  max_length buffer str.to_cstr stdin read
 
   // Store the string length
   buffer cast(ptr) int.store

--- a/lib/std.torth
+++ b/lib/std.torth
@@ -1186,9 +1186,11 @@ end
 // Arena allocator
 
 // 4064 + ArenaRegion.size == 4096 == PAGE_SIZE
-const ARENA_REGION_MIN_CAPACITY 4064 end
+const ARENA_REGION_MIN_CAPACITY 4096 end
 // Minimum space left to not update the `current` region
 const ARENA_CURRENT_MIN_SPACE 128 end
+// Chunk sizes within regions
+const ARENA_CHUNK_SIZE 64 end
 
 class ArenaAllocator
     first:ArenaRegion   // First region of the arena
@@ -1217,6 +1219,10 @@ class ArenaAllocator
 
     // Allocate `bytes` for ArenaAllocator
     method allocate self:ArenaAllocator bytes:int -> ptr :
+        // Round `bytes` up to the nearest chunk
+        ARENA_CHUNK_SIZE bytes ARENA_CHUNK_SIZE % - bytes +
+        bytes =
+
         // Find region with enough free space
         bytes self ArenaAllocator.find_region take region in
 
@@ -1240,7 +1246,6 @@ class ArenaAllocator
 
     // Append region to the end of the ArenaAllocator
     method append_region self:ArenaAllocator region:ArenaRegion :
-        self ArenaAllocator.first cast(int) puti " arst\n" puts
         if self ArenaAllocator.first NULL == do
             region self ArenaAllocator->first
             region self ArenaAllocator->current

--- a/lib/std.torth
+++ b/lib/std.torth
@@ -1220,13 +1220,7 @@ class Arena
     last:ArenaRegion    // Last region in the arena
 
     method init capacity:int -> Arena :
-        Arena.size malloc cast(Arena)   take arena in
-        capacity ArenaRegion.init       take region in
-
-        region arena Arena->first
-        region arena Arena->current
-        region arena Arena->last
-        arena
+        Arena.size malloc cast(Arena)
     end
 
     // Find region with enough space from the arena or allocate one
@@ -1270,7 +1264,13 @@ class Arena
 
     // Append region to the end of the Arena
     method append_region self:Arena region:ArenaRegion :
-        region self Arena.last ArenaRegion->next
+        self Arena.first cast(int) puti " arst\n" puts
+        if self Arena.first NULL == do
+            region self Arena->first
+            region self Arena->current
+        else
+            region self Arena.last ArenaRegion->next
+        endif
         region self Arena->last
     end
 

--- a/lib/std.torth
+++ b/lib/std.torth
@@ -80,18 +80,18 @@ function fputs fd:int buf:str : buf str.len buf str.to_cstr fd write drop end
 // Allocate read-write memory and return the pointer to the allocated memory
 // Params: size_t length
 // Return: Pointer to the start of the allocated memory
-function malloc length:int -> ptr :
-  // Allocate at least one byte
-  if length 0 <= do
-    1 length =
-  endif
-
+function mmap length:int -> ptr :
   // mmap ( NULL, length, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, 0, 0 );
   0 0
   MAP_ANONYMOUS MAP_PRIVATE |
   PROT_READ PROT_WRITE |
   length
   NULL SYS_mmap SYSCALL6 cast(ptr)
+end
+
+// Allocate memory using built-in `ArenaAllocator`
+function malloc int -> ptr :
+    arena ArenaAllocator.allocate
 end
 
 // Deallocate memory
@@ -123,7 +123,10 @@ function cstr.to_string cstring:cstr -> str :
     endif
 
     // Allocate memory for string
-    cstring_len int.size + malloc cast(str)
+    cstring_len
+    int.size +    // First 8 bytes contain the string length
+    1 +           // NULL byte
+    malloc cast(str)
     take string in
 
     // Save the string length
@@ -236,7 +239,8 @@ end
 
 function char.to_string character:char -> str :
   1 peek string_len in
-  int.size + // First 8 bytes contain the string length
+  int.size +    // First 8 bytes contain the string length
+  1 +           // NULL byte
   malloc cast(str)
   take string in
 
@@ -298,7 +302,7 @@ function itoa num:int -> str :
 
   // Allocate memory to the string representation
   num int.get_digits
-  dup int.size + malloc cast(str)
+  dup int.size + 1 + malloc cast(str)
   10
   take
     base
@@ -372,7 +376,8 @@ inline function str.store    ptr str   ->      : STORE_QWORD                   e
 function str.copy string:str -> str :
   // Allocate memory which can store the string
   string str.len
-  int.size + // First 8 bytes contain the string length
+  int.size +    // First 8 bytes contain the string length
+  1 +           // NULL byte
   malloc
 
   // Fill the new memory with string content
@@ -499,7 +504,7 @@ function str.replace
   // Store the string length
   string str.copy peek string_start in
   str.len index - substring str.len - peek end_len in
-  int.size + malloc cast(str) take string_end in
+  int.size + 1 + malloc cast(str) take string_end in
   end_len string_end cast(ptr) int.store
 
   // Copy the end of string from index to `string_end`
@@ -577,14 +582,14 @@ function str.cat str2:str str1:str -> str :
   str1
   take result str1.len str2.len in
 
-  str1.len int.size + PAGE_SIZE %
-  str2.len          + PAGE_SIZE >
+  str1.len int.size + ARENA_CHUNK_SIZE %
+  str2.len + 1      + ARENA_CHUNK_SIZE >
   str1 str.is_static ||
   take requires_allocation in
 
   if requires_allocation do
     // Allocate memory to hold both string
-    str1.len str2.len + int.size + malloc
+    str1.len str2.len + int.size + 1 + malloc
 
     // Fill the beginning of the allocated memory with str1
     str1 str.fill result =
@@ -610,7 +615,7 @@ function str.append string:str character:char -> str :
   string str.len
   take string_len required_extra_space in
 
-  string_len PAGE_SIZE % PAGE_SIZE required_extra_space - >
+  string_len ARENA_CHUNK_SIZE % ARENA_CHUNK_SIZE required_extra_space - >
   string str.is_static ||
   take requires_allocation in
 
@@ -645,7 +650,7 @@ function str.prepend string:str character:char -> str :
 
   // Test if the character fits in the current memory page
   // String literals cannot be appended so them always require allocation
-  string_len PAGE_SIZE % PAGE_SIZE required_extra_space - >
+  string_len ARENA_CHUNK_SIZE % ARENA_CHUNK_SIZE required_extra_space - >
   string str.is_static ||
   take requires_allocation in
 
@@ -749,7 +754,7 @@ end
 function str.alphanumeric string:str -> str :
   // Allocate enough memory to hold the whole string
   string str.len
-  dup int.size + malloc cast(str)
+  dup int.size + 1 + malloc cast(str)
   0
   take index buffer string_len in
 
@@ -881,7 +886,7 @@ end
 function str.reverse original:str -> str :
   // Allocate memory for the reversed string
   original str.len
-  dup int.size + malloc cast(str)
+  dup int.size + 1 + malloc cast(str)
   take reversed index in
 
   // Append characters from the parameter string to allocated memory in the reversed order
@@ -1198,7 +1203,7 @@ class ArenaAllocator
     last:ArenaRegion    // Last region in the arena
 
     method init capacity:int -> ArenaAllocator :
-        ArenaAllocator.size malloc cast(ArenaAllocator)
+        ArenaAllocator.size mmap cast(ArenaAllocator)
     end
 
     // Find region with enough space from the arena or allocate one
@@ -1294,7 +1299,7 @@ class ArenaRegion
         if capacity ARENA_REGION_MIN_CAPACITY < do
             ARENA_REGION_MIN_CAPACITY capacity =
         endif
-        capacity ArenaRegion.size + malloc cast(ArenaRegion)
+        capacity ArenaRegion.size + mmap cast(ArenaRegion)
         take region in
 
         0                                       region ArenaRegion->count

--- a/lib/std.torth
+++ b/lib/std.torth
@@ -1203,7 +1203,7 @@ end
 // Arena allocator
 
 // 4064 + ArenaRegion.size == 4096 == PAGE_SIZE
-const ARENA_REGION_MIN_CAPACITY 4096 end
+const ARENA_REGION_MIN_CAPACITY 4064 end
 // Minimum space left to not update the `current` region
 const ARENA_CURRENT_MIN_SPACE 128 end
 // Chunk sizes within regions

--- a/lib/typing.torth
+++ b/lib/typing.torth
@@ -24,15 +24,6 @@ class Array
         cast(Array) // Return Array
     end
 
-    // Free the allocated memory for a certain array
-    // Params: array (PTR)
-    // Return: None
-    method delete Array :
-        take array in
-        array Array.len int.size * int.size +
-        array cast(ptr) munmap
-    end
-
     // Get the length of an array (number of elements)
     // Params: array (PTR)
     // Return: len (INT)
@@ -358,18 +349,6 @@ class List
         list
     end
 
-    // Free the allocated memory for a certain list
-    method delete List :
-        dup List.array
-        take array list in
-
-        // Deallocate the array pointed by List.array
-        array Array.delete
-
-        // Deallocate the List object
-        List.size list cast(ptr) munmap
-    end
-
     // Append value pointer to a list
     // Params: list (PTR), value (ANY)
     // Return: list (PTR)
@@ -404,9 +383,6 @@ class List
 
             // Update new array length
             len new_array cast(ptr) int.store
-
-            // Deallocate the old array
-            array Array.delete
 
             // Set the new_array to array
             new_array array =
@@ -582,9 +558,6 @@ function LinkedList.pop Node -> ptr :
     // Unlink the old head
     head Node.next head_ptr cast(ptr) Node.store
 
-    // Deallocate the old head
-    Node.size head cast(ptr) munmap
-
     // Return the popped data
     popped_data
 end
@@ -614,17 +587,6 @@ function LinkedList.is_empty Node -> bool :
     cast(ptr) int.load 0 ==
 end
 
-function LinkedList.delete linked_list:Node data_size:int :
-    linked_list cast(ptr) Node.load
-    take node in
-
-    while node cast(int) NULL != do
-        node Node.next
-        data_size node Node.delete
-        take node in
-    done
-end
-
 class Node
     data:ptr
     next:Node
@@ -636,12 +598,6 @@ class Node
 
     method store ptr Node :
         swap cast(ptr) swap ptr.store
-    end
-
-    method delete node:Node data_size:int :
-        // Deallocate the Node with its data
-        data_size node Node.data munmap
-        Node.size node cast(ptr) munmap
     end
 endclass // Node
 
@@ -759,9 +715,6 @@ class HashMap
                 if prev cast(int) NULL != do
                     next prev Node->next
                 endif
-
-                // Deallocate the deleted node
-                Pair.size node Node.delete
                 return
             endif
             node Node.next node =

--- a/torth_ls.torth
+++ b/torth_ls.torth
@@ -575,7 +575,7 @@ function main :
     State.init take state in
 
     while True do
-        state input handle_request
+        state 4096 input handle_request
 
         // Cache the current state
         // TODO: Only parse when there are changes


### PR DESCRIPTION
### Main changes

- Introduce new intrinsic `ARENA` which pushes built-in `ArenaAllocator` to the stack.
- Migrate `malloc` to use the built-in arena allocator
  - Repurpose old `malloc` function as `mmap` function
- Fix functions that use `malloc` to be more specific on the amount of space they require
  - Many string-related functions did not include room for null byte. Thus, conversion from `str` to `cstr` with `str.to_cstr` function potentially overwrites data from the next chunk.

### Other changes

- Remove `delete` functions for objects
  - Objects allocated to an arena can be deallocated at once using `ArenaAllocator.delete`.
- Implement `fd.size` function in `std` library which gets the size of the file referred by file descriptor
- Add `max_length` parameter to `input` function so that it does not allocate too much memory unnecessarily